### PR TITLE
Add defaultLazy utility extension.

### DIFF
--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
@@ -212,6 +212,22 @@ fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.default(value: EachT)
 }
 
 /**
+ * If the option is not called on the command line (and is not set in an envvar), use the lazy [value] for the option.
+ *
+ * This must be applied after all other transforms.
+ *
+ * Example:
+ *
+ * ```kotlin
+ * val opt: Pair<Int, Int> by option().int().pair().defaultLazy { (1..100).sum() to 2 }
+ * ```
+ */
+fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.defaultLazy(value: () -> EachT)
+    : OptionWithValues<EachT, EachT, ValueT> {
+    return transformAll { it.lastOrNull() ?: value() }
+}
+
+/**
  * If the option is not called on the command line (and is not set in an envvar), throw a [MissingParameter].
  *
  * This must be applied after all other transforms.

--- a/clikt/src/test/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
+++ b/clikt/src/test/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
@@ -316,6 +316,22 @@ class OptionTest {
     }
 
     @Test
+    fun `default lazy option`() = parameterized(
+            row("", "55"),
+            row("--x 3", "3"),
+            row("-x4", "4")) { (argv, expected) ->
+        class C : CliktCommand() {
+            private val sum: Int by lazy { (1..10).sum() }
+            val x by option("-x", "--x").defaultLazy { "$sum" }
+            override fun run() {
+                assertThat(x).called("x").isEqualTo(expected)
+            }
+        }
+
+        C().parse(splitArgv(argv))
+    }
+
+    @Test
     fun `required option`() {
         class C : CliktCommand() {
             val x by option().required()


### PR DESCRIPTION
Sometimes, the default value provided for an option requires a more complex computation (e.g., for a git-like program, the default commit to process could be the head commit, but finding the head commit hash is not straightforward).

If a registered subcommand performs such computations at initialization time, it could throw an error even if the subcommand wasn't invoked on the command line or if a specific value was provided for the problematic option, thus not needing to evaluate the default value. The defaultLazy method can fix this situation.