### PR TITLE
Fix wrapping on options with long help messages

### DIFF
--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/output/text.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/output/text.kt
@@ -32,7 +32,7 @@ private fun StringBuilder.wrapParagraph(text: String, width: Int, initialIndent:
     var currentWidth = initialIndent.length
     for ((i, word) in words.withIndex()) {
         if (i > 0) {
-            if (currentWidth + word.length >= width) {
+            if (currentWidth + word.length + 1 > width) {
                 append("\n").append(subsequentIndent)
                 currentWidth = subsequentIndent.length
             } else {

--- a/clikt/src/test/kotlin/com/github/ajalt/clikt/output/PlaintextHelpFormatterTest.kt
+++ b/clikt/src/test/kotlin/com/github/ajalt/clikt/output/PlaintextHelpFormatterTest.kt
@@ -196,6 +196,24 @@ class PlaintextHelpFormatterTest {
     }
 
     @Test
+    fun `formatHelp option wrapping long help issue #10`() {
+        val f = PlaintextHelpFormatter(width = 62)
+        f.formatHelp("", "", l(
+                opt(l("-L", "--lorem-ipsum"),
+                        help = "Lorem ipsum dolor sit amet, consectetur e  adipiscing elit. Nulla vitae " +
+                                "porta nisi.  Interdum et malesuada fames ac ante ipsum")
+        ), programName = "prog") shouldBe
+                """
+                |Usage: prog [OPTIONS]
+                |
+                |Options:
+                |  -L, --lorem-ipsum  Lorem ipsum dolor sit amet, consectetur e
+                |                     adipiscing elit. Nulla vitae porta nisi.
+                |                     Interdum et malesuada fames ac ante ipsum
+                """.trimMargin("|")
+    }
+
+    @Test
     fun `formatHelp arguments`() {
         val f = PlaintextHelpFormatter(width = 54)
         f.formatHelp("", "", l(

--- a/clikt/src/test/kotlin/com/github/ajalt/clikt/output/TextExtensionsTest.kt
+++ b/clikt/src/test/kotlin/com/github/ajalt/clikt/output/TextExtensionsTest.kt
@@ -15,13 +15,13 @@ class TextExtensionsTest {
             row("a c".wrapText(width = 2), "a\nc"),
             row("a b c".wrapText(width = 3), "a b\nc"),
             row("a bc".wrapText(width = 3), "a\nbc"),
-            row("abc".wrapText(initialIndent = "1", subsequentIndent = "2"), "1abc"),
-            row("a b c".wrapText(width = 4, initialIndent = "1", subsequentIndent = "2"), "1a b\n2c"),
-            row("a b c".wrapText(width = 3, initialIndent = "1 "), "1 a\nb c"),
+            row("abc".wrapText(initialIndent = "=", subsequentIndent = "-"), "=abc"),
+            row("a b c".wrapText(width = 4, initialIndent = "=", subsequentIndent = "-"), "=a b\n-c"),
+            row("a b c".wrapText(width = 3, initialIndent = "= "), "= a\nb c"),
             row("a\n\nb".wrapText(width = 3, preserveParagraph = true), "a\n\nb"),
             row("a b c\n\nd e f".wrapText(width = 3, preserveParagraph = true), "a b\nc\n\nd e\nf"),
-            row("a b c\n\nd e f".wrapText(width = 4, initialIndent = "1",
-                    subsequentIndent = "2", preserveParagraph = true), "1a b\n2c\n\n2d e\n2f"),
+            row("a b c\n\nd e f".wrapText(width = 4, initialIndent = "=",
+                    subsequentIndent = "-", preserveParagraph = true), "=a b\n-c\n\n-d e\n-f"),
             row("".wrapText(), "")
     ) { (actual, expected) ->
         actual shouldBe expected


### PR DESCRIPTION
Fixes #10

The problem was the wrap width was calculated based on the space remaining after the option names. This works for the first line, but subsequent lines have a width that's shorter than it should be.

e.g. 

```
              width=17
          /---------------\ 
--option  lorem ipsum dolor
          sit
          amet
\--------------/
    width=17
```

The fix is to use the option name and spacing as the initial indent, and wrap to the full width:

```
        width=28
/-------------------------\ 
  inital indent
/--------\
--option  lorem ipsum dolor
          sit amet
\-------------------------/
       width=28