### PR TITLE
Support uppercase responses in TermUi.confirm()

### DIFF
--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/output/TermUi.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/output/TermUi.kt
@@ -147,7 +147,7 @@ object TermUi {
                 if (default) "Y/n" else "y/N")
         val rv: Boolean
         l@ while (true) {
-            val input = promptForLine(prompt, false)?.trim() ?: return null
+            val input = promptForLine(prompt, false)?.trim()?.toLowerCase() ?: return null
             rv = when (input) {
                 "y", "yes" -> true
                 "n", "no" -> false


### PR DESCRIPTION
Currently TermUi.confirm() only supports lowercase answers ("y", "n").
Since the input suggestion highlights the default value "y/N" or "Y/n", inexperienced users may try to enter uppercase characters. The case should make no difference on the response here.