### PR TITLE
Add `path` paramter type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,12 +32,13 @@ subprojects {
         testImplementation 'junit:junit:4.12'
         testImplementation 'io.kotlintest:kotlintest-assertions:3.1.7'
         testImplementation 'com.github.stefanbirkner:system-rules:1.17.0'
+        testImplementation 'com.google.jimfs:jimfs:1.1'
     }
 
     compileKotlin {
-        kotlinOptions.jvmTarget = "1.6"
+        kotlinOptions.jvmTarget = "1.8"
     }
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "1.6"
+        kotlinOptions.jvmTarget = "1.8"
     }
 }

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/types/file.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/types/file.kt
@@ -25,7 +25,7 @@ private fun convertToFile(path: String,
     val name = pathType(fileOkay, folderOkay)
     return File(path).also {
         if (exists && !it.exists()) fail("$name \"$it\" does not exist.")
-        if (!fileOkay && it.isFile) fail("$name \"$it\" is a file")
+        if (!fileOkay && it.isFile) fail("$name \"$it\" is a file.")
         if (!folderOkay && it.isDirectory) fail("$name \"$it\" is a directory.")
         if (writable && !it.canWrite()) fail("$name \"$it\" is not writable.")
         if (readable && !it.canRead()) fail("$name \"$it\" is not readable.")

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
@@ -1,5 +1,6 @@
 package com.github.ajalt.clikt.parameters.types
 
+import com.github.ajalt.clikt.output.TermUi
 import com.github.ajalt.clikt.parameters.arguments.ProcessedArgument
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
@@ -28,7 +29,7 @@ private fun convertToPath(path: String,
     val name = pathType(fileOkay, folderOkay)
     return fileSystem.getPath(path).also {
         if (exists && !Files.exists(it)) fail("$name \"$it\" does not exist.")
-        if (!fileOkay && Files.isRegularFile(it)) fail("$name \"$it\" is a file")
+        if (!fileOkay && Files.isRegularFile(it)) fail("$name \"$it\" is a file.")
         if (!folderOkay && Files.isDirectory(it)) fail("$name \"$it\" is a directory.")
         if (writable && !Files.isWritable(it)) fail("$name \"$it\" is not writable.")
         if (readable && !Files.isReadable(it)) fail("$name \"$it\" is not readable.")
@@ -72,7 +73,7 @@ fun RawOption.path(exists: Boolean = false,
                    readable: Boolean = false,
                    fileSystem: FileSystem = java.nio.file.FileSystems.getDefault()): NullableOption<Path, Path> {
     val name = pathType(fileOkay, folderOkay)
-    val split = if (com.github.ajalt.clikt.output.TermUi.isWindows) kotlin.text.Regex.fromLiteral(";") else kotlin.text.Regex.fromLiteral(":")
+    val split = if (TermUi.isWindows) Regex.fromLiteral(";") else Regex.fromLiteral(":")
     return convert(name.toUpperCase(), envvarSplit = split) {
         convertToPath(it, exists, fileOkay, folderOkay, writable, readable, fileSystem) { fail(it) }
     }

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
@@ -1,0 +1,79 @@
+package com.github.ajalt.clikt.parameters.types
+
+import com.github.ajalt.clikt.parameters.arguments.ProcessedArgument
+import com.github.ajalt.clikt.parameters.arguments.RawArgument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.options.NullableOption
+import com.github.ajalt.clikt.parameters.options.RawOption
+import com.github.ajalt.clikt.parameters.options.convert
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+
+private fun pathType(fileOkay: Boolean, folderOkay: Boolean): String = when {
+    fileOkay && !folderOkay -> "File"
+    !fileOkay && folderOkay -> "Directory"
+    else -> "Path"
+}
+
+private fun convertToPath(path: String,
+                          exists: Boolean,
+                          fileOkay: Boolean,
+                          folderOkay: Boolean,
+                          writable: Boolean,
+                          readable: Boolean,
+                          fileSystem: FileSystem,
+                          fail: (String) -> Unit): Path {
+    val name = pathType(fileOkay, folderOkay)
+    return fileSystem.getPath(path).also {
+        if (exists && !Files.exists(it)) fail("$name \"$it\" does not exist.")
+        if (!fileOkay && Files.isRegularFile(it)) fail("$name \"$it\" is a file")
+        if (!folderOkay && Files.isDirectory(it)) fail("$name \"$it\" is a directory.")
+        if (writable && !Files.isWritable(it)) fail("$name \"$it\" is not writable.")
+        if (readable && !Files.isReadable(it)) fail("$name \"$it\" is not readable.")
+    }
+}
+
+/**
+ * Convert the argument to a [Path].
+ *
+ * @param exists If true, fail if the given path does not exist
+ * @param fileOkay If false, fail if the given path is a file
+ * @param folderOkay If false, fail if the given path is not a directory
+ * @param writable If true, fail if the given path is not writable
+ * @param readable If true, fail if the given path is not readable
+ * @param fileSystem If specified, the [FileSystem] with which to resolve paths.
+ */
+fun RawArgument.path(
+        exists: Boolean = false,
+        fileOkay: Boolean = true,
+        folderOkay: Boolean = true,
+        writable: Boolean = false,
+        readable: Boolean = false,
+        fileSystem: FileSystem = FileSystems.getDefault()): ProcessedArgument<Path, Path> = convert {
+    convertToPath(it, exists, fileOkay, folderOkay, writable, readable, fileSystem) { fail(it) }
+}
+
+/**
+ * Convert the option to a [Path].
+ *
+ * @param exists If true, fail if the given path does not exist
+ * @param fileOkay If false, fail if the given path is a file
+ * @param folderOkay If false, fail if the given path is not a directory
+ * @param writable If true, fail if the given path is not writable
+ * @param readable If true, fail if the given path is not readable
+ * @param fileSystem If specified, the [FileSystem] with which to resolve paths.
+ */
+fun RawOption.path(exists: Boolean = false,
+                   fileOkay: Boolean = true,
+                   folderOkay: Boolean = true,
+                   writable: Boolean = false,
+                   readable: Boolean = false,
+                   fileSystem: FileSystem = java.nio.file.FileSystems.getDefault()): NullableOption<Path, Path> {
+    val name = pathType(fileOkay, folderOkay)
+    val split = if (com.github.ajalt.clikt.output.TermUi.isWindows) kotlin.text.Regex.fromLiteral(";") else kotlin.text.Regex.fromLiteral(":")
+    return convert(name.toUpperCase(), envvarSplit = split) {
+        convertToPath(it, exists, fileOkay, folderOkay, writable, readable, fileSystem) { fail(it) }
+    }
+}

--- a/clikt/src/test/kotlin/com/github/ajalt/clikt/parameters/types/PathTest.kt
+++ b/clikt/src/test/kotlin/com/github/ajalt/clikt/parameters/types/PathTest.kt
@@ -1,5 +1,6 @@
 package com.github.ajalt.clikt.parameters.types
 
+import com.github.ajalt.clikt.core.BadParameterValue
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
@@ -8,13 +9,17 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.testing.splitArgv
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
+import io.kotlintest.fail
 import io.kotlintest.shouldBe
+import java.nio.file.Files
+import java.nio.file.FileSystem
 import org.junit.Test
 
 class PathTest {
+    val fs: FileSystem = Jimfs.newFileSystem(Configuration.unix())
+
     @Test
     fun `paths are resolved using the provided filesystem, if any`() {
-        val fs = Jimfs.newFileSystem(Configuration.unix())
         val command = object : CliktCommand() {
             val path by option("-p")
                     .path(fileSystem = fs)
@@ -56,5 +61,60 @@ class PathTest {
         }
 
         command.parse(splitArgv("foo bar baz"))
+    }
+
+    @Test
+    fun `fileOkay = false will reject files`() {
+        val command = object : CliktCommand() {
+            val folderOnly by option("-f").path(fileOkay = false, fileSystem = fs)
+
+            override fun run() {
+            }
+        }
+
+        Files.createDirectory(fs.getPath("/var"))
+        Files.createFile(fs.getPath("/var/foo"))
+
+        expectBadParameter("Invalid value for \"-f\": Directory \"/var/foo\" is a file.") {
+            command.parse(splitArgv("-f/var/foo"))
+        }
+    }
+
+    @Test
+    fun `folderOkay = false will reject folders`() {
+        val command = object : CliktCommand() {
+            val fileOnly by option("-f").path(folderOkay = false, fileSystem = fs)
+
+            override fun run() {
+            }
+        }
+
+        Files.createDirectories(fs.getPath("/var/foo"))
+
+        expectBadParameter("Invalid value for \"-f\": File \"/var/foo\" is a directory.") {
+            command.parse(splitArgv("-f/var/foo"))
+        }
+    }
+
+    @Test fun `exists = true will reject paths that don't exist` () {
+        val command = object : CliktCommand() {
+            val homeDir by option("-h").path(exists = true, fileSystem = fs)
+
+            override fun run() {
+            }
+        }
+
+        expectBadParameter("Invalid value for \"-h\": Path \"/home/cli\" does not exist.") {
+            command.parse(splitArgv("-h /home/cli"))
+        }
+    }
+
+    private inline fun expectBadParameter(message: String, fn: () -> Unit) {
+        try {
+            fn()
+            fail("parse should have failed with a BadParameterValue exception")
+        } catch (e: BadParameterValue) {
+            e.message shouldBe message
+        }
     }
 }

--- a/clikt/src/test/kotlin/com/github/ajalt/clikt/parameters/types/PathTest.kt
+++ b/clikt/src/test/kotlin/com/github/ajalt/clikt/parameters/types/PathTest.kt
@@ -1,0 +1,60 @@
+package com.github.ajalt.clikt.parameters.types
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.testing.splitArgv
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import io.kotlintest.shouldBe
+import org.junit.Test
+
+class PathTest {
+    @Test
+    fun `paths are resolved using the provided filesystem, if any`() {
+        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val command = object : CliktCommand() {
+            val path by option("-p")
+                    .path(fileSystem = fs)
+                    .required()
+
+            override fun run() {
+                path.fileSystem shouldBe fs
+            }
+        }
+
+        command.parse(splitArgv("-p/var/log/foo"))
+    }
+
+    @Test
+    fun `options can be paths`() {
+        val command = object : CliktCommand() {
+            val path by option("-p")
+                    .path()
+                    .required()
+
+            override fun run() {
+                path.toString() shouldBe "foo"
+            }
+        }
+
+        command.parse(splitArgv("-pfoo"))
+    }
+
+    @Test
+    fun `arguments can be paths`() {
+        val command = object : CliktCommand() {
+            val paths by argument()
+                    .path()
+                    .multiple()
+
+            override fun run() {
+                paths.map { it.toString() } shouldBe listOf("foo", "bar", "baz")
+            }
+        }
+
+        command.parse(splitArgv("foo bar baz"))
+    }
+}


### PR DESCRIPTION
This adds a parameter type for `java.nio.Path`, analogous to the existing `file` type.  It _also_ bumps the target JDK to 1.8, which is probably fine given that Java 8 has been out since 2014.

Fixes #14