### PR TITLE
Add ability to customize io streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Ability to use alternate output streams rather than stdin and stdout by setting `Context.console`.
 
 ## [1.4.0] - 2018-07-31
 ### Added
@@ -8,7 +10,7 @@
 
 ### Changed
 - Clikt now targets JVM 8 bytecode
-- Responses to `TermUi.confirm()` are now case-insensitive 
+- Responses to `TermUi.confirm()` are now case-insensitive
 
 ## [1.3.0] - 2018-06-23
 ### Added

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
@@ -28,7 +28,7 @@ import kotlin.system.exitProcess
  * @param invokeWithoutSubcommand Used when this command has subcommands, and this command is called
  *   without a subcommand. If true, [run] will be called. By default, a [PrintHelpMessage] is thrown instead.
  */
-abstract class CliktCommand constructor(
+abstract class CliktCommand(
         help: String = "",
         epilog: String = "",
         name: String? = null,
@@ -128,6 +128,21 @@ abstract class CliktCommand constructor(
     open fun aliases(): Map<String, List<String>> = emptyMap()
 
     /**
+     * Print the [message] to the screen.
+     *
+     * This is similar to [print] or [println], but converts newlines to the system line separator.
+     *
+     * This is equivalent to calling [TermUi.echo] with the console from the current context.
+     *
+     * @param message The message to print.
+     * @param trailingNewline If true, behave like [println], otherwise behave like [print]
+     * @param err If true, print to stderr instead of stdout
+     */
+    fun echo(message: Any?, trailingNewline: Boolean = true, err: Boolean = false) {
+        TermUi.echo(message, trailingNewline, err, context.console)
+    }
+
+    /**
      * Parse the command line and throw an exception if parsing fails.
      *
      * You should use [main] instead unless you want to handle output yourself.
@@ -151,19 +166,19 @@ abstract class CliktCommand constructor(
         try {
             parse(argv)
         } catch (e: PrintHelpMessage) {
-            TermUi.echo(e.command.getFormattedHelp())
+            echo(e.command.getFormattedHelp())
             exitProcess(0)
         } catch (e: PrintMessage) {
-            TermUi.echo(e.message)
+            echo(e.message)
             exitProcess(0)
         } catch (e: UsageError) {
-            TermUi.echo(e.helpMessage(context), err = true)
+            echo(e.helpMessage(context), err = true)
             exitProcess(1)
         } catch (e: CliktError) {
-            TermUi.echo(e.message, err = true)
+            echo(e.message, err = true)
             exitProcess(1)
         } catch (e: Abort) {
-            TermUi.echo("Aborted!", err = true)
+            echo("Aborted!", err = true)
             exitProcess(1)
         }
     }

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/core/Context.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/core/Context.kt
@@ -1,7 +1,9 @@
 package com.github.ajalt.clikt.core
 
+import com.github.ajalt.clikt.output.CliktConsole
 import com.github.ajalt.clikt.output.HelpFormatter
 import com.github.ajalt.clikt.output.PlaintextHelpFormatter
+import com.github.ajalt.clikt.output.defaultCliktConsole
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -32,7 +34,8 @@ class Context(val parent: Context?,
               val helpOptionNames: Set<String>,
               val helpOptionMessage: String,
               val helpFormatter: HelpFormatter,
-              val tokenTransformer: Context.(String) -> String) {
+              val tokenTransformer: Context.(String) -> String,
+              val console: CliktConsole) {
     var invokedSubcommand: CliktCommand? = null
         internal set
     var obj: Any? = null
@@ -93,6 +96,13 @@ class Context(val parent: Context?,
         var autoEnvvarPrefix: String? = parent?.autoEnvvarPrefix?.let {
             it + "_" + command.commandName.replace(Regex("\\W"), "_").toUpperCase()
         }
+
+        /**
+         * The console that will handle reading and writing text.
+         *
+         * The default uses [System.in] and [System.out].
+         */
+        var console: CliktConsole = defaultCliktConsole()
     }
 
     companion object {
@@ -100,7 +110,7 @@ class Context(val parent: Context?,
             with(Builder(command, parent)) {
                 block()
                 return Context(parent, command, allowInterspersedArgs, autoEnvvarPrefix,
-                        helpOptionNames, helpOptionMessage, helpFormatter, tokenTransformer)
+                        helpOptionNames, helpOptionMessage, helpFormatter, tokenTransformer, console)
             }
         }
     }

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/output/CliktConsole.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/output/CliktConsole.kt
@@ -1,0 +1,73 @@
+package com.github.ajalt.clikt.output
+
+import java.io.Console
+import java.io.IOException
+
+interface CliktConsole {
+    /**
+     * Show the [prompt] to the user, and return a line of their response.
+     *
+     * This function will block until a line of input has been read.
+     *
+     * @param prompt The text to display to the user
+     * @param hideInput If true, the user's input should not be echoed to the screen. If the current console
+     *   does not support hidden input, this argument may be ignored..
+     * @return A line of user input, or null if an error occurred.
+     */
+    fun promptForLine(prompt: String, hideInput: Boolean): String?
+
+    /**
+     * Show some [text] to the user.
+     *
+     * @param text The text to display. May or may not contain a tailing newline.
+     * @param error If true, the [text] is an error message, and should be printed in an alternate stream or
+     *   format, if applicable.
+     */
+    fun print(text: String, error: Boolean)
+
+    /**
+     * The line separator to use. (Either "\n" or "\r\n")
+     */
+    val lineSeparator: String
+}
+
+class InteractiveCliktConsole(private val console: Console) : CliktConsole {
+    override fun promptForLine(prompt: String, hideInput: Boolean) = when {
+        hideInput -> console.readPassword(prompt)?.let { String(it) }
+        else -> console.readLine(prompt)
+    }
+
+    override fun print(text: String, error: Boolean) {
+        if (error) {
+            System.err
+        } else {
+            System.out
+        }.print(text)
+    }
+
+    override val lineSeparator: String get() = System.lineSeparator()
+}
+
+class NonInteractiveCliktConsole : CliktConsole {
+    override fun promptForLine(prompt: String, hideInput: Boolean) = try {
+        print(prompt, false)
+        System.`in`.bufferedReader().readLine()
+    } catch (err: IOException) {
+        null
+    }
+
+    override fun print(text: String, error: Boolean) {
+        if (error) {
+            System.err
+        } else {
+            System.out
+        }.print(text)
+    }
+
+    override val lineSeparator: String get() = System.lineSeparator()
+}
+
+fun defaultCliktConsole(): CliktConsole {
+    return System.console()?.let { InteractiveCliktConsole(it) }
+            ?: NonInteractiveCliktConsole()
+}

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
@@ -1,6 +1,11 @@
 package com.github.ajalt.clikt.parameters.options
 
-import com.github.ajalt.clikt.core.*
+import com.github.ajalt.clikt.core.Abort
+import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.MissingParameter
+import com.github.ajalt.clikt.core.UsageError
 import com.github.ajalt.clikt.output.TermUi
 import com.github.ajalt.clikt.parameters.internal.NullableLateinit
 import com.github.ajalt.clikt.parameters.types.int
@@ -225,7 +230,7 @@ fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.default(value: EachT)
  * ```
  */
 inline fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.defaultLazy(crossinline value: () -> EachT)
-    : OptionWithValues<EachT, EachT, ValueT> {
+        : OptionWithValues<EachT, EachT, ValueT> {
     return transformAll { it.lastOrNull() ?: value() }
 }
 
@@ -406,12 +411,12 @@ fun <T : Any> NullableOption<T, T>.prompt(
             ?.replace(Regex("\\W"), " ")?.capitalize() ?: "Value"
 
     val provided = it.lastOrNull()
-    if (provided != null) provided
-    else {
-        TermUi.prompt(promptText, default, hideInput, requireConfirmation,
-                confirmationPrompt, promptSuffix, showDefault) {
+    when (provided) {
+        null -> TermUi.prompt(promptText, default, hideInput, requireConfirmation,
+                confirmationPrompt, promptSuffix, showDefault, context.console) {
             val ctx = OptionCallTransformContext("", this, context)
             transformAll(listOf(transformEach(ctx, listOf(transformValue(ctx, it)))))
-        } ?: throw Abort()
-    }
+        }
+        else -> provided
+    } ?: throw Abort()
 }

--- a/samples/helpformat/src/main/kotlin/com/github/ajalt/clikt/samples/helpformat/main.kt
+++ b/samples/helpformat/src/main/kotlin/com/github/ajalt/clikt/samples/helpformat/main.kt
@@ -38,7 +38,7 @@ class Echo : CliktCommand(help = "Echo the STRING(s) to standard output") {
     override fun run() {
         val message = if (strings.isEmpty()) String(System.`in`.readBytes())
         else strings.joinToString(" ", postfix = if (suppressNewline) "" else "\n")
-        TermUi.echo(message, trailingNewline = false)
+        echo(message, trailingNewline = false)
     }
 }
 

--- a/samples/plugins/src/main/kotlin/com/github/ajalt/clikt/samples/plugins/clone.kt
+++ b/samples/plugins/src/main/kotlin/com/github/ajalt/clikt/samples/plugins/clone.kt
@@ -31,12 +31,12 @@ class Clone : CliktCommand(
 
     override fun run() {
         val destName = dest ?: File(src).name
-        TermUi.echo("Cloning repo $src to ${File(destName).absolutePath}")
+        echo("Cloning repo $src to ${File(destName).absolutePath}")
         repo.home = destName
         if (shallow) {
-            TermUi.echo("Making shallow checkout")
+            echo("Making shallow checkout")
         }
-        TermUi.echo("Checking out revision $rev")
+        echo("Checking out revision $rev")
     }
 }
 

--- a/samples/plugins/src/main/kotlin/com/github/ajalt/clikt/samples/plugins/commit.kt
+++ b/samples/plugins/src/main/kotlin/com/github/ajalt/clikt/samples/plugins/commit.kt
@@ -45,19 +45,19 @@ class Commit : CliktCommand(
 
             val message = TermUi.editText(text)
             if (message == null) {
-                TermUi.echo("Aborted!")
+                echo("Aborted!")
                 return
             }
             message.split(marker, limit = 2)[0].trim().apply {
                 if (this.isEmpty()) {
-                    TermUi.echo("Aborting commit due to empty commit message.")
+                    echo("Aborting commit due to empty commit message.")
                     return
                 }
             }
         }
-        TermUi.echo("Files to be commited: $files")
-        TermUi.echo("Commit message:")
-        TermUi.echo(msg)
+        echo("Files to be commited: $files")
+        echo("Commit message:")
+        echo(msg)
     }
 }
 

--- a/samples/plugins/src/main/kotlin/com/github/ajalt/clikt/samples/plugins/delete.kt
+++ b/samples/plugins/src/main/kotlin/com/github/ajalt/clikt/samples/plugins/delete.kt
@@ -15,8 +15,8 @@ class Delete : CliktCommand(
     val repo: Repo by requireObject()
 
     override fun run() {
-        TermUi.echo("Destroying repo ${repo.home}")
-        TermUi.echo("Deleted!")
+        echo("Destroying repo ${repo.home}")
+        echo("Deleted!")
     }
 }
 

--- a/samples/repo/src/main/kotlin/com/github/ajalt/clikt/samples/repo/main.kt
+++ b/samples/repo/src/main/kotlin/com/github/ajalt/clikt/samples/repo/main.kt
@@ -58,12 +58,12 @@ class Clone : CliktCommand(
 
     override fun run() {
         val destName = dest ?: File(src).name
-        TermUi.echo("Cloning repo $src to ${File(destName).absolutePath}")
+        echo("Cloning repo $src to ${File(destName).absolutePath}")
         repo.home = destName
         if (shallow) {
-            TermUi.echo("Making shallow checkout")
+            echo("Making shallow checkout")
         }
-        TermUi.echo("Checking out revision $rev")
+        echo("Checking out revision $rev")
     }
 }
 
@@ -74,8 +74,8 @@ class Delete : CliktCommand(
     val repo: Repo by requireObject()
 
     override fun run() {
-        TermUi.echo("Destroying repo ${repo.home}")
-        TermUi.echo("Deleted!")
+        echo("Destroying repo ${repo.home}")
+        echo("Deleted!")
     }
 }
 
@@ -96,7 +96,7 @@ class SetUser : CliktCommand(
         repo.config["username"] = username
         repo.config["email"] = email
         repo.config["password"] = "*".repeat(password.length)
-        TermUi.echo("Changed credentials.")
+        echo("Changed credentials.")
     }
 }
 
@@ -132,19 +132,19 @@ class Commit : CliktCommand(
 
             val message = TermUi.editText(text)
             if (message == null) {
-                TermUi.echo("Aborted!")
+                echo("Aborted!")
                 return
             }
             message.split(marker, limit = 2)[0].trim().apply {
                 if (this.isEmpty()) {
-                    TermUi.echo("Aborting commit due to empty commit message.")
+                    echo("Aborting commit due to empty commit message.")
                     return
                 }
             }
         }
-        TermUi.echo("Files to be commited: $files")
-        TermUi.echo("Commit message:")
-        TermUi.echo(msg)
+        echo("Files to be commited: $files")
+        echo("Commit message:")
+        echo(msg)
     }
 }
 

--- a/samples/validation/src/main/kotlin/com/github/ajalt/clikt/samples/validation/main.kt
+++ b/samples/validation/src/main/kotlin/com/github/ajalt/clikt/samples/validation/main.kt
@@ -42,11 +42,11 @@ class Cli : CliktCommand(help = "Validation examples") {
         if (biggerCount != null && count != null && biggerCount!! <= count!!) {
             throw BadParameterValue("--bigger-count must be larger than --count")
         }
-        TermUi.echo("count: $count")
-        TermUi.echo("biggerCount: $biggerCount")
-        TermUi.echo("quad: $quad")
-        TermUi.echo("sum: $sum")
-        TermUi.echo("url: $url")
+        echo("count: $count")
+        echo("biggerCount: $biggerCount")
+        echo("quad: $quad")
+        echo("sum: $sum")
+        echo("url: $url")
     }
 
 }


### PR DESCRIPTION
This commit adds `CliktConsole`, which is now used instead of stdout/stdin/stderr directly. You can provide your own implementation by setting the new `console` property on the context.