### PR TITLE
Test for Context.console inheritance

### DIFF
--- a/clikt/src/test/kotlin/com/github/ajalt/clikt/output/PlaintextHelpFormatterTest.kt
+++ b/clikt/src/test/kotlin/com/github/ajalt/clikt/output/PlaintextHelpFormatterTest.kt
@@ -293,7 +293,7 @@ class PlaintextHelpFormatterTest {
                 |  --foo INT         foo option help
                 |  -b, --bar META    bar option help
                 |  --baz / --no-baz  baz option help
-                |  --version         Show the version and exit.
+                |  --version         Show the version and exit
                 |  -h, --help        Show this message and exit
                 |
                 |Commands:


### PR DESCRIPTION
I encountered a bug in 1.5.0 where Context.console is no inherited from the parent by subCommands. I created what I thought would be a failing test case which ended up passing the first time.

Additionally, in order for me to do this I had to fix the PlaintextHelpFormatterTest.