### PR TITLE
Fix relative links to API in docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -11,10 +11,9 @@ invoke a command by typing a prefix of its name, or user-defined aliases
 like the way you can configure git to accept `git ci` as an alias for
 `git commit`.
 
-To implement command aliases, override
-[`CliktCommand.aliases`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/aliases/) in your
-command. This function is called once at the start of parsing, and returns a map of aliases to the
-tokens that they alias to.
+To implement command aliases, override [`CliktCommand.aliases`][aliases] in your command.
+This function is called once at the start of parsing,
+and returns a map of aliases to the tokens that they alias to.
 
 To implement git-style aliases:
 
@@ -98,8 +97,8 @@ Running Bar
 
 To prevent ambiguities in parsing, aliases are only supported for
 command names. However, there's another way to modify user input that
-works on more types of tokens. You can set a [`tokenTransformer`](api/clikt/com.github.ajalt.clikt.core/-context/token-transformer/) on the
-[command's context](commands.md#customizing-contexts) that will be
+works on more types of tokens. You can set a [`tokenTransformer`][tokenTransformer] on the
+[command's context][customizing-context] that will be
 called for each option and command name that is input. This can be used
 to implement case-insensitive parsing, for example:
 
@@ -121,12 +120,11 @@ Hello Foo!
 
 ## Replacing stdin and stdout
 
-By default, functions like [`CliktCommand.main`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/)
-and [`option().prompt()`](api/clikt/com.github.ajalt.clikt.parameters.options/prompt/)
+By default, functions like [`CliktCommand.main`][main] and [`option().prompt()`][prompt]
 read from `System.in` and write to `System.out`. If you want to use
 clikt in an environment where the standard streams aren't available, you
-can set your own implementation of [`CliktConsole`](api/clikt/com.github.ajalt.clikt.output/-clikt-console/)
-when [customizing the command context](commands.md#customizing-contexts).
+can set your own implementation of [`CliktConsole`][CliktConsole]
+when [customizing the command context][customizing-context].
 
 ```kotlin
 object MyConsole : CliktConsole {
@@ -150,9 +148,8 @@ class CustomCLI : CliktCommand() {
 }
 ```
 
-If you are using
-[`TermUI`](api/clikt/com.github.ajalt.clikt.output/-term-ui/)
-directly, you can also pass your custom console as an argument.
+If you are using [`TermUI`][TermUI] directly,
+you can also pass your custom console as an argument.
 
 ## Command Line Argument Files
 
@@ -201,3 +198,12 @@ recursively.
 
 An unescaped `#` character outside of quotes is treated as a line comment: it and the rest of the
 line are skipped. You can pass a literal `#` by escaping it with `\#` or quoting it with `'#'`.
+
+
+[aliases]: ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/aliases/
+[tokenTransformer]:     ../api/clikt/com.github.ajalt.clikt.core/-context/token-transformer/
+[customizing-context]:  ../commands/#customizing-contexts
+[main]:    ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/
+[prompt]:               ../api/clikt/com.github.ajalt.clikt.parameters.options/prompt/
+[CliktConsole]:         ../api/clikt/com.github.ajalt.clikt.output/-clikt-console/
+[TermUI]:               ../api/clikt/com.github.ajalt.clikt.output/-term-ui/

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -1,13 +1,14 @@
 # Arguments
 
-Arguments are declared and customized similarly to
-[options](options.md), but are provided on the command line
-positionally instead of by name. Arguments are declared with [`argument()`](api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/), and the order that they are declared defines the order that they
+Arguments are declared and customized similarly to [options][options],
+but are provided on the command line positionally instead of by name.
+Arguments are declared with [`argument()`][argument],
+and the order that they are declared defines the order that they
 must be provided on the command line.
 
 ## Basic Arguments
 
-By default, [`argument`](api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/) takes a single `String` value which is required to be
+By default, [`argument`][argument] takes a single `String` value which is required to be
 provided on the command line.
 
 ```kotlin tab="Example"
@@ -50,9 +51,8 @@ Options:
 
 ## Variadic Arguments
 
-Like [options](options.md), arguments can take any fixed number of values, which you can change with
-functions like [`pair`](api/clikt/com.github.ajalt.clikt.parameters.arguments/pair/) and
-[`triple`](api/clikt/com.github.ajalt.clikt.parameters.arguments/triple/). Unlike options,
+Like [options][options], arguments can take any fixed number of values, which you can change with
+functions like [`pair`][pair] and [`triple`][triple]. Unlike options,
 arguments can take a variable (or unlimited) number of values. This is especially common when taking
 file paths, since they are frequently expanded with a glob pattern on the command line.
 
@@ -108,3 +108,9 @@ $ ./touch --verbose -- --foo.txt bar.txt
 --foo.txt
 bar.txt
 ```
+
+
+[options]:  ../options/
+[argument]: ../api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/
+[pair]:     ../api/clikt/com.github.ajalt.clikt.parameters.arguments/pair/
+[triple]:   ../api/clikt/com.github.ajalt.clikt.parameters.arguments/triple/

--- a/docs/autocomplete.md
+++ b/docs/autocomplete.md
@@ -4,10 +4,10 @@ Clikt includes built-in support for generating autocomplete scripts for bash and
 
 ## Supported Functionality
 
-Currently subcommand, option, and [command alias](advanced.md) names can be completed, as well as
+Currently subcommand, option, and [command alias][command-aliases] names can be completed, as well as
 values for options and arguments. `choice` parameters are completed with their possible values.
-Other parameter types are completed as file or directory names. `Context.allowInterspersedArgs` is
-supported.
+Other parameter types are completed as file or directory names.
+[`Context.allowInterspersedArgs`][allowInterspersedArgs] is supported.
 
 For example:
 
@@ -29,10 +29,10 @@ the script once each time your CLI changes, and load it each time your start you
 
 To generate the shell script, you need to invoke your program with a special environment variable.
 You can set the variable name manually with the `autoCompleteEnvvar` parameter in the
-[`CliktCommand` constructor](api/clikt/com.github.ajalt.clikt.core/-clikt-command/). By
-default it's your command's name capitalized, with `-` replaced with `_`, and prefixed with another
-`_`. So if your command name is `my-command`, the variable would be `_MY_COMMAND_COMPLETE=bash` or
-`_MY_COMMAND_COMPLETE=zsh`, depending on your current shell.
+[`CliktCommand` constructor][CliktCommand]. By default it's your command's name capitalized,
+with `-` replaced with `_`, and prefixed with another `_`.
+So if your command name is `my-command`, the variable would be `_MY_COMMAND_COMPLETE=bash`
+or `_MY_COMMAND_COMPLETE=zsh`, depending on your current shell.
 
 For example to activate bash autocomplete for this command:
 
@@ -64,15 +64,11 @@ You'll need to regenerate the completion script any time your command structure 
 
 ## Customizing Completions
 
-There is built-in completion for values for
-[`choice`](api/clikt/com.github.ajalt.clikt.parameters.types/choice/) parameters, and for
-parameters converted with [`file`](api/clikt/com.github.ajalt.clikt.parameters.types/file/) and
-[`path`](api/clikt/com.github.ajalt.clikt.parameters.types/path/).
+There is built-in completion for values for [`choice`][choice] parameters,
+and for parameters converted with [`file`][file] and [`path`][path].
 
 You can add completion for other parameters with the `completionCandidates` parameter to
-[`option()`](api/clikt/com.github.ajalt.clikt.parameters.options/option/) and
-[`argument()`](api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/). The value can
-be one of the following:
+[`option()`][option] and [`argument()`][argument]. The value can be one of the following:
 
 - `None`: The default. The parameter's values will not be completed.
 - `Path`: Completions will be filesystem paths.
@@ -82,10 +78,21 @@ be one of the following:
 
 ## Limitations
 
-[Token Normalization](/advanced/#token-normalization) is not supported.
+[Token Normalization][token-normalization] is not supported.
 
 If you have arguments that occur after a `multiple` argument, those arguments won't be
 autocompleted. Partial command lines are ambiguous in those situations, and Clikt assumes that
 you're trying to complete the `multiple` argument rather than the later ones.
 
 Bash must be at least version 3, or Zsh must be at least version 4.1.
+
+
+[command-aliases]:       ../advanced/#command-aliases
+[allowInterspersedArgs]: ../api/clikt/com.github.ajalt.clikt.core/-context/allow-interspersed-args/
+[CliktCommand]:          ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/
+[choice]:                ../api/clikt/com.github.ajalt.clikt.parameters.types/choice/
+[file]:                  ../api/clikt/com.github.ajalt.clikt.parameters.types/file/
+[path]:                  ../api/clikt/com.github.ajalt.clikt.parameters.types/path/
+[option]:                ../api/clikt/com.github.ajalt.clikt.parameters.options/option/
+[argument]:              ../api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/
+[token-normalization]:   ../advanced/#token-normalization

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,13 +1,13 @@
 # Commands
 
 Clikt supports arbitrarily nested commands. You can add one command as a child of another with the
-[`subcommands`](api/clikt/com.github.ajalt.clikt.core/subcommands/) function, which can be
+[`subcommands`][subcommands] function, which can be
 called either in an `init` block, or on an existing instance.
 
 ## Executing Nested Commands
 
 For commands with no children,
-[`run`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/run/) is called whenever the
+[`run`][run] is called whenever the
 command line is parsed (unless parsing is aborted from an error or an option like `--help`).
 
 If a command has children, this isn't the case. Instead, its `run` is
@@ -54,7 +54,7 @@ executing
 
 The default name for subcommands is inferred as a lowercase name from the command class name. You
 can also set a name manually in the
-[`CliktCommand`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/) constructor.
+[`CliktCommand`][CliktCommand] constructor.
 
 ```kotlin tab="Example"
 class Tool : CliktCommand() {
@@ -144,7 +144,7 @@ out `Tool`'s help page as if you just typed `./tool --help`.
 Normally nested command are independent of each other: a child can't
 access its parent's parameters. This makes composing commands much
 easier, but what if you want to pass information to a child command? You
-can do so with the command's [`Context`](api/clikt/com.github.ajalt.clikt.core/-context/).
+can do so with the command's [`Context`][Context].
 
 Every time the command line is parsed, each command creates a new
 context object for itself that is liked to its parent's context.
@@ -179,16 +179,14 @@ $ ./tool --verbose execute
 Verbose mode is on
 ```
 
-The [`findObject`](api/clikt/com.github.ajalt.clikt.core/find-object/) and
-[`requireObject`](api/clikt/com.github.ajalt.clikt.core/require-object/) functions will walk up
+The [`findObject`][findObject] and [`requireObject`][requireObject] functions will walk up
 the context tree until they find an object with the given type. If no such object exists, they will
 either return `null`, throw an exception, or create an instance of the object and store it on the
 command's context, depending on which overload you call.
 
 ## Running Parent Command Without Children
 
-Normally, if a command has children,
-[`run`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/run/) is not called unless a child
+Normally, if a command has children, [`run`][run] is not called unless a child
 command is invoked on the command line. Instead, `--help` is called on the parent. If you want to
 change this behavior to always call `run()` on the parent, you can do so by setting
 `invokeWithoutSubcommand` to `true`. The `Context` will then have information on the subcommand that
@@ -227,10 +225,10 @@ running subcommand
 
 ## Customizing Contexts
 
-[Contexts](api/clikt/com.github.ajalt.clikt.core/-context/) have a number of properties
-that can be customized, and which are inherited by child commands. You can change these properties
-with the [`context`](api/clikt/com.github.ajalt.clikt.core/context/) builder function, which can
-be called in an `init` block, or on a command instance.
+[Contexts][Context] have a number of properties that can be customized,
+and which are inherited by child commands.
+You can change these properties with the [`context`][context] builder function,
+which can be called in an `init` block, or on a command instance.
 
 For example, you can change the default help message for the `--help`
 option. These definitions are equivalent:
@@ -265,9 +263,7 @@ Options:
 ## Printing the Help Message When No Arguments Are Given
 
 Normally, if a command is called with no values on the command line, a usage error is printed if
-there are required parameters, or
-[`run`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/run/) is called if there aren't
-any.
+there are required parameters, or [`run`][run] is called if there aren't any.
 
 You can change this behavior by passing `printHelpOnEmptyArgs = true` to your command's
 constructor. This will cause a help message to be printed when to values are provided on the command
@@ -291,17 +287,17 @@ Options:
 
 ## Warnings and Other Messages
 
-When you want to show information to the user, you'll probably use the [functions for printing to
-stdout](/quickstart/#printing-to-stdout-and-stderr) directly. 
+When you want to show information to the user, you'll probably use the
+[functions for printing to stdout][printing-to-stdout-and-stderr] directly.
 
 However, there's another mechanism that can be more useful when writing reusable parameter code:
 command messages. These messages are buffered during parsing and printed all at once immediately
-before a command's [`run`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/run/) is called.
+before a command's [`run`][run] is called.
 They are not printed if there are any errors in parsing. This type of message is used by Clikt for
-[`deprecating options`](/options/#deprecating-options).
+[`deprecating options`][deprecating-options].
 
 You can issue a command message by calling
-[`CliktCommand.message`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/issue-message/) or with the
+[`CliktCommand.issueMessage`][issueMessage] or with the
 `message` function available in the context of parameter transformers.
 
 ```kotlin tab="Example"
@@ -324,7 +320,7 @@ $ ./cli --opt='' --oops
 Error: no such option: "--oops".
 ```
 
-You can disable automatic message printing on the [command's context](#customizing-contexts):
+You can disable automatic message printing on the [command's context][customizing-context]:
 
 ```kotlin tab="Example"
 class Cli : CliktCommand() {
@@ -342,3 +338,16 @@ class Cli : CliktCommand() {
 $ ./cli --opt=''
 command run
 ```
+
+
+[subcommands]:                   ../api/clikt/com.github.ajalt.clikt.core/subcommands/
+[run]:                           ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/run/
+[CliktCommand]:                  ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/
+[Context]:                       ../api/clikt/com.github.ajalt.clikt.core/-context/
+[findObject]:                    ../api/clikt/com.github.ajalt.clikt.core/find-object/
+[requireObject]:                 ../api/clikt/com.github.ajalt.clikt.core/require-object/
+[context]:                       ../api/clikt/com.github.ajalt.clikt.core/context/
+[printing-to-stdout-and-stderr]: ../quickstart/#printing-to-stdout-and-stderr
+[deprecating-options]:           ../options/#deprecating-options
+[issueMessage]:                  ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/issue-message/
+[customizing-context]:           #customizing-contexts

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -1,16 +1,15 @@
 # Documenting Scripts
 
-Clikt takes care of creating formatted help messages for commands. There
-are a number of ways to customize the default behavior. You can also
-implement your own [`HelpFormatter`](api/clikt/com.github.ajalt.clikt.output/-help-formatter/) and set it on the [command's
-context](commands.md#customizing-contexts).
+Clikt takes care of creating formatted help messages for commands.
+There are a number of ways to customize the default behavior.
+You can also implement your own [`HelpFormatter`][HelpFormatter]
+and set it on the [command's context][customizing-contexts].
 
 ## Help Texts
 
-[Commands](api/clikt/com.github.ajalt.clikt.core/-clikt-command/) and parameters accept a `help` argument. Commands also accept an
+[Commands][Commands] and parameters accept a `help` argument. Commands also accept an
 `epilog` argument, which is printed after the parameters and commands on
-the help page. All text is automatically re-wrapped to the terminal
-width.
+the help page. All text is automatically re-wrapped to the terminal width.
 
 ```kotlin tab="Example"
 class Hello : CliktCommand(help = """
@@ -46,9 +45,8 @@ describe arguments in the command help.
 
 ## Subcommand Short Help
 
-Subcommands are listed in the help page based on their
-[name](commands.md#customizing-command-name). They have a short help
-string which is the first line of their help.
+Subcommands are listed in the help page based on their [name][customizing-command-name].
+They have a short help string which is the first line of their help.
 
 ```kotlin tab="Example"
 class Tool : NoRunCliktCommand()
@@ -83,7 +81,7 @@ not used for the help option. If the help option has no unique names, it
 is not added.
 
 You can change the help option's name and help message on the
-[command's context](commands.md#customizing-contexts):
+[command's context][customizing-context]:
 
 ```kotlin tab="Example"
 class Tool : NoRunCliktCommand() {
@@ -112,8 +110,7 @@ If you don't want a help option to be added, you can set
 You can configure the help formatter to show default values in the help output by passing
 `showRequiredTag = true` to the `CliktHelpFormatter`. By default, the string value of the
 default value will be shown. You can show a different value by passing the value you want to show to
-the `defaultForHelp` parameter of
-[`default`](api/clikt/com.github.ajalt.clikt.parameters.options/default/).
+the `defaultForHelp` parameter of [`default`][default].
 
 ```kotlin tab="Example"
 class Tool : NoRunCliktCommand() {
@@ -136,15 +133,15 @@ Options:
 ```
 
 
-## Required Options in Help 
+## Required Options in Help
 
-By default, [`required`](api/clikt/com.github.ajalt.clikt.parameters.options/required/) options
+By default, [`required`][required] options
 are displayed the same way as other options. The help formatter includes two different ways to show
 that an option is required.
 
 ### Required Option Marker
 
-You can pass a character to the `requiredOptionMarker` argument of the `CliktHelpFormatter`. 
+You can pass a character to the `requiredOptionMarker` argument of the `CliktHelpFormatter`.
 
 ```kotlin tab="Example"
 class Tool : NoRunCliktCommand() {
@@ -195,7 +192,7 @@ Options:
 ## Grouping Options in Help
 
 You can group options into separate help sections by using
-[OptionGroup](api/clikt/com.github.ajalt.clikt.parameters.groups/-option-group/).
+[OptionGroup][OptionGroup].
 The name of the group will be shown in the output. You can also add an extra help message to be
 shown with the group. Groups can't be nested.
 
@@ -228,6 +225,16 @@ Options:
 ### Note for IntelliJ users:
 
 If you're using IntelliJ, there is a bug in the Kotlin plugin for versions 1.2.31 and under that prevents
-[provideDelegate](api/clikt/com.github.ajalt.clikt.parameters.groups/provide-delegate/)
+[provideDelegate][provideDelegate]
 from being imported automatically, so you might need to add this import manually: `import
 com.github.ajalt.clikt.parameters.groups.provideDelegate`
+
+
+[HelpFormatter]:            ../api/clikt/com.github.ajalt.clikt.output/-help-formatter/
+[Commands]:                 ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/
+[customizing-command-name]: ../commands/#customizing-command-name
+[customizing-context]:      ../commands/#customizing-contexts
+[default]:                  ../api/clikt/com.github.ajalt.clikt.parameters.options/default/
+[required]:                 ../api/clikt/com.github.ajalt.clikt.parameters.options/required/
+[OptionGroup]:              ../api/clikt/com.github.ajalt.clikt.parameters.groups/-option-group/
+[provideDelegate]:          ../api/clikt/com.github.ajalt.clikt.parameters.groups/provide-delegate/

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -5,31 +5,23 @@ early for any reason. This includes incorrect command line usage, or
 printing a help page.
 
 ## Where are Exceptions Handled? {#handling}
-When you call [`CliktCommand.main`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/),
-it will parse the command line and catch any
-[`CliktError`](api/clikt/com.github.ajalt.clikt.core/-clikt-error/) and
-[`Abort`](api/clikt/com.github.ajalt.clikt.core/-abort/) exceptions. If it catches one, it
-will then print out the appropriate information and exit the process. If the caught exception is a
-[`PrintMessage`](api/clikt/com.github.ajalt.clikt.core/-print-message/) or
-[`PrintHelpMessage`](api/clikt/com.github.ajalt.clikt.core/-print-help-message/), the
-process exit status will be 0 and the message will be printed to stdout. Otherwise it will exit with
-status 1 and print the message to stderr.
+When you call [`CliktCommand.main`][main], it will parse the command line and catch any
+[`CliktError`][CliktError] and [`Abort`][Abort] exceptions.
+If it catches one, it will then print out the appropriate information and exit the process.
+If the caught exception is a [`PrintMessage`][PrintMessage] or [`PrintHelpMessage`][PrintHelpMessage],
+the process exit status will be 0 and the message will be printed to stdout.
+Otherwise it will exit with status 1 and print the message to stderr.
 
-Any other types of exceptions indicate a programming error, and are not caught by
-[`main`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/). However,
-[`convert`](api/clikt/com.github.ajalt.clikt.parameters.options/convert/) and the other
-parameter transformations will wrap exceptions thrown inside them in a
-[`UsageError`](api/clikt/com.github.ajalt.clikt.core/-usage-error/), so if you define a
-custom transformation, you don't have to worry about an exception escaping to the user.
+Any other types of exceptions indicate a programming error, and are not caught by [`main`][main].
+However, [`convert`][convert] and the other parameter transformations will wrap exceptions thrown
+inside them in a [`UsageError`][UsageError], so if you define a custom transformation,
+you don't have to worry about an exception escaping to the user.
 
 ## Handling Exceptions Manually
 
-[`CliktCommand.main`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/) is just a
-`try`/`catch` block surrounding
-[`CliktCommand.parse`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/parse/), so if don't
-want exceptions to be caught, you can call
-[`parse`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/parse/) wherever you would
-normally call [`main`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/).
+[`CliktCommand.main`][main] is just a `try`/`catch` block surrounding
+[`CliktCommand.parse`][parse], so if don't want exceptions to be caught,
+you can call [`parse`][parse] wherever you would normally call [`main`][main].
 
 ```kotlin
 fun main(args: Array<String>) = Cli().parse(args)
@@ -37,18 +29,34 @@ fun main(args: Array<String>) = Cli().parse(args)
 
 ## Which Exceptions Exist?
 
-Clikt will throw [`Abort`](api/clikt/com.github.ajalt.clikt.core/-abort/) if
-it needs to halt execution immediately without a specific message. All
-other exceptions are subclasses of [`UsageError`](api/clikt/com.github.ajalt.clikt.core/-usage-error/).
+Clikt will throw [`Abort`][Abort]
+if it needs to halt execution immediately without a specific message.
+All other exceptions are subclasses of [`UsageError`][UsageError].
 
 The following subclasses exist:
 
-* [`PrintMessage`](api/clikt/com.github.ajalt.clikt.core/-print-message/) : The exception's message should be printed.
-* [`PrintHelpMessage`](api/clikt/com.github.ajalt.clikt.core/-print-help-message/) : The help page for the exception's command should be printed.
-* [`UsageError`](api/clikt/com.github.ajalt.clikt.core/-usage-error/) : The command line was incorrect in some way. All other exceptions subclass from this. These exceptions are automatically augmented with extra information about the current parameter, if possible.
-* [`BadParameterValue`](api/clikt/com.github.ajalt.clikt.core/-bad-parameter-value/) : A parameter was given the correct number of values, but of invalid format or type.
-* [`MissingParameter`](api/clikt/com.github.ajalt.clikt.core/-missing-parameter/) : A required parameter was not provided.
-* [`NoSuchOption`](api/clikt/com.github.ajalt.clikt.core/-no-such-option/) : An option was provided that does not exist.
-* [`IncorrectOptionValueCount`](api/clikt/com.github.ajalt.clikt.core/-incorrect-option-value-count/) : An option was supplied but the number of values supplied to the option was incorrect.
-* [`IncorrectArgumentValueCount`](api/clikt/com.github.ajalt.clikt.core/-incorrect-argument-value-count/) : An argument was supplied but the number of values supplied was incorrect.
-* [`MutuallyExclusiveGroupException`](api/clikt/com.github.ajalt.clikt.core/-mutually-exclusive-group-exception/) : Multiple options in a mutually exclusive group were supplied when the group is restricted to a single value.
+* [`PrintMessage`][PrintMessage] : The exception's message should be printed.
+* [`PrintHelpMessage`][PrintHelpMessage] : The help page for the exception's command should be printed.
+* [`UsageError`][UsageError] : The command line was incorrect in some way. All other exceptions subclass from this. These exceptions are automatically augmented with extra information about the current parameter, if possible.
+* [`BadParameterValue`][BadParameterValue] : A parameter was given the correct number of values, but of invalid format or type.
+* [`MissingParameter`][MissingParameter] : A required parameter was not provided.
+* [`NoSuchOption`][NoSuchOption] : An option was provided that does not exist.
+* [`IncorrectOptionValueCount`][IncorrectOptionValueCount] : An option was supplied but the number of values supplied to the option was incorrect.
+* [`IncorrectArgumentValueCount`][IncorrectArgumentValueCount] : An argument was supplied but the number of values supplied was incorrect.
+* [`MutuallyExclusiveGroupException`][MutuallyExclusiveGroupException] : Multiple options in a mutually exclusive group were supplied when the group is restricted to a single value.
+
+
+[main]:                            ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/
+[CliktError]:                      ../api/clikt/com.github.ajalt.clikt.core/-clikt-error/
+[Abort]:                           ../api/clikt/com.github.ajalt.clikt.core/-abort/
+[PrintMessage]:                    ../api/clikt/com.github.ajalt.clikt.core/-print-message/
+[PrintHelpMessage]:                ../api/clikt/com.github.ajalt.clikt.core/-print-help-message/
+[convert]:                         ../api/clikt/com.github.ajalt.clikt.parameters.options/convert/
+[UsageError]:                      ../api/clikt/com.github.ajalt.clikt.core/-usage-error/
+[parse]:                           ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/parse/
+[BadParameterValue]:               ../api/clikt/com.github.ajalt.clikt.core/-bad-parameter-value/
+[MissingParameter]:                ../api/clikt/com.github.ajalt.clikt.core/-missing-parameter/
+[NoSuchOption]:                    ../api/clikt/com.github.ajalt.clikt.core/-no-such-option/
+[IncorrectOptionValueCount]:       ../api/clikt/com.github.ajalt.clikt.core/-incorrect-option-value-count/
+[IncorrectArgumentValueCount]:     ../api/clikt/com.github.ajalt.clikt.core/-incorrect-argument-value-count/
+[MutuallyExclusiveGroupException]: ../api/clikt/com.github.ajalt.clikt.core/-mutually-exclusive-group-exception/

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,7 +1,7 @@
 # Options
 
 Options are added to commands by defining a property delegate with the
-[`option`](api/clikt/com.github.ajalt.clikt.parameters.options/option/) function.
+[`option`][option] function.
 
 ## Basic Options
 
@@ -71,8 +71,7 @@ Hello, foo!
 ## Customizing Options
 
 The option behavior and delegate type can be customized by calling extension functions on the
-[`option`](api/clikt/com.github.ajalt.clikt.parameters.options/option/) call. For example, here
-are some different option declarations:
+[`option`][option] call. For example, here are some different option declarations:
 
 ```kotlin
 val a: String? by option()
@@ -87,20 +86,16 @@ independently:
 
 1. **The type of each value in the option.**
    The value type is `String` by default, but can be customized with built-in functions like
-   [`int`](api/clikt/com.github.ajalt.clikt.parameters.types/int/) or
-   [`choice`](api/clikt/com.github.ajalt.clikt.parameters.types/choice/), or manually with
-   [`convert`](api/clikt/com.github.ajalt.clikt.parameters.options/convert/). This is detailed
-   in the [parameters](parameters.md#parameter-types) page.
+   [`int`][int] or [`choice`][choice], or manually with [`convert`][convert].
+   This is detailed in the [parameters][parameter-types] page.
 2. **The number of values that the option requires.**
    Options take one value by default, but this can be changed with
-   built-in functions like [`pair`](api/clikt/com.github.ajalt.clikt.parameters.options/pair/)
-   and [`triple`](api/clikt/com.github.ajalt.clikt.parameters.options/triple/), or manually with
-   [`transformValues`](api/clikt/com.github.ajalt.clikt.parameters.options/transform-values/).
+   built-in functions like [`pair`][pair] and [`triple`][triple], or manually with
+   [`transformValues`][transformValues].
 3. **How to handle all calls to the option (i.e. if the option is not given, or is given more than once).**
    By default, the option delegate value is the null if the option is
    not given on the command line, but you can change this behavior with
-   functions like [`default`](api/clikt/com.github.ajalt.clikt.parameters.options/default/) and
-   [`multiple`](api/clikt/com.github.ajalt.clikt.parameters.options/multiple/).
+   functions like [`default`][default] and [`multiple`][multiple].
 
 Since the three types of customizations are orthogonal, you can choose
 which ones you want to use, and if you implement a new customization, it
@@ -110,8 +105,7 @@ code.
 ## Default Values
 
 By default, option delegates return `null` if the option wasn't provided
-on the command line. You can instead return a default value with 
-[`default`](api/clikt/com.github.ajalt.clikt.parameters.options/default/).
+on the command line. You can instead return a default value with [`default`][default].
 
 ```kotlin tab="Example"
 class Pow : CliktCommand() {
@@ -133,27 +127,24 @@ $ ./pow
 ```
 
 If the default value is expensive to compute, you can use
-[`defaultLazy`](api/clikt/com.github.ajalt.clikt.parameters.options/default-lazy/) instead of
-[`default`](api/clikt/com.github.ajalt.clikt.parameters.options/default/). It has the same
-effect, but you give it a lambda returning the default value, and the lambda will only be called if
-the default value is used.
+[`defaultLazy`][defaultLazy] instead of [`default`][default].
+It has the same effect, but you give it a lambda returning the default value,
+and the lambda will only be called if the default value is used.
 
 ## Multi Value Options
 
-Options can take any fixed number of values separated by whitespace, or a variable number of values
-separated by a non-whitespace delimiter you specify. If you want a variable number of values
-separated by whitespace, you need to use an argument instead.
+Options can take any fixed number of values separated by whitespace,
+or a variable number of values separated by a non-whitespace delimiter you specify.
+If you want a variable number of values separated by whitespace, you need to use an argument instead.
 
 ### Options With Fixed Number of Values
 
-There are built in functions for options that take two values
-([`pair`](api/clikt/com.github.ajalt.clikt.parameters.options/pair/), which uses a `Pair`), or
-three values ([`triple`](api/clikt/com.github.ajalt.clikt.parameters.options/triple/), which
-uses a `Triple`).  You can change the type of each value as normal with functions like
-[`int`](api/clikt/com.github.ajalt.clikt.parameters.types/int/).
+There are built in functions for options that take two values ([`pair`][pair], which uses a `Pair`),
+or three values ([`triple`][triple], which uses a `Triple`).
+You can change the type of each value as normal with functions like [`int`][int].
 
 If you need more values, you can provide your own container with
-[`transformValues`](api/clikt/com.github.ajalt.clikt.parameters.options/transform-values/). You
+[`transformValues`][transformValues]. You
 give that function the number of values you want, and a lambda that will transform a list of values
 into the output container. The list will always have a size equal to the number you specify. If the
 user provides a different number of values, Clikt will inform the user and your lambda won't be
@@ -184,7 +175,7 @@ Tesseract has dimensions 6x7x8x9
 
 ### Options With a Variable Number of Values
 
-You can use [`split`](api/clikt/com.github.ajalt.clikt.parameters.options/split/) to allow a
+You can use [`split`][split] to allow a
 variable number of values to a single option invocation by separating the values with non-whitespace
 delimiters.
 
@@ -212,7 +203,7 @@ Normally, when an option is provided on the command line more than once,
 only the values from the last occurrence are used. But sometimes you
 want to keep all values provided. For example, `git commit -m foo -m
 bar` would create a commit message with two lines: `foo` and `bar`. To
-get this behavior with Clikt, you can use [`multiple`](api/clikt/com.github.ajalt.clikt.parameters.options/multiple/). This will cause the property
+get this behavior with Clikt, you can use [`multiple`][multiple]. This will cause the property
 delegate value to be a list, where each item in the list is the value of
 from one occurrence of the option. If the option is never given, the
 list will be empty (or you can specify a list to use).
@@ -232,8 +223,8 @@ foo
 bar
 ```
 
-You can combine [`multiple`](api/clikt/com.github.ajalt.clikt.parameters.options/multiple/) with item type conversions and multiple values. For
-example:
+You can combine [`multiple`][multiple] with item type conversions and multiple values.
+For example:
 
 ```kotlin
 val opt: List<Pair<Int, Int>> by option().int().pair().multiple()
@@ -243,7 +234,7 @@ val opt: List<Pair<Int, Int>> by option().int().pair().multiple()
 
 Flags are options that don't take a value. Boolean flags can be enabled
 or disabled, depending on the name used to invoke the option. You can
-turn an option into a boolean flag with [`flag`](api/clikt/com.github.ajalt.clikt.parameters.options/flag/). That function takes an optional
+turn an option into a boolean flag with [`flag`][flag]. That function takes an optional
 list of secondary names that will be added to any existing or inferred
 names for the option. If the option is invoked with one of the secondary
 names, the delegate will return false. It's a good idea to always set
@@ -293,7 +284,7 @@ true true Foo
 ## Counted Flag Options
 
 You might want a flag option that counts the number of times it occurs on the command line. You can
-use [`counted`](api/clikt/com.github.ajalt.clikt.parameters.options/counted/) for this.
+use [`counted`][counted] for this.
 
 ```kotlin tab="Example"
 class Log : CliktCommand() {
@@ -312,7 +303,7 @@ Verbosity level: 3
 ## Feature Switch Flags
 
 Another way to use flags is to assign a value to each option name. You can do this with
-[`switch`](api/clikt/com.github.ajalt.clikt.parameters.options/switch/), which takes a map of
+[`switch`][switch], which takes a map of
 option names to values. Note that the names in the map replace any previously specified or inferred
 names.
 
@@ -335,7 +326,7 @@ You picked size small
 ## Choice Options
 
 You can restrict the values that a regular option can take to a set of values using
-[`choice`](api/clikt/com.github.ajalt.clikt.parameters.types/choice/). You can also map the
+[`choice`][choice]. You can also map the
 input values to new types.
 
 ```kotlin tab="Example"
@@ -370,9 +361,8 @@ Options:
 
 ## Mutually Exclusive Option Groups
 
-If [`choice`](#choice-options) or [`switch`](#feature-switch-flags) options aren't flexible enough,
-you can use
-[`mutuallyExclusiveOptions`](api/clikt/com.github.ajalt.clikt.parameters.groups/mutually-exclusive-options/)
+If [`choice`][choice] or [`switch`][switch] options aren't flexible enough,
+you can use [`mutuallyExclusiveOptions`][mutuallyExclusiveOptions]
 to group any nullable options into a mutually exclusive group. If more than one of the options in
 the group is given on the command line, the last value is used.
 
@@ -412,8 +402,7 @@ Usage: order [OPTIONS]
 Error: option --apples cannot be used with --oranges
 ```
 
-You can enforce that only one of the options is given with
-[`single`](api/clikt/com.github.ajalt.clikt.parameters.groups/single/):
+You can enforce that only one of the options is given with [`single`][single]:
 
 ```kotlin tab="Example"
 val fruit: Fruit? by mutuallyExclusiveOptions<Fruit>(
@@ -430,19 +419,18 @@ Error: option --apples cannot be used with --oranges
 ```
 
 Like regular options, you can make the entire group
-[`required`](api/clikt/com.github.ajalt.clikt.parameters.groups/required/), or give it a
-[`default`](api/clikt/com.github.ajalt.clikt.parameters.groups/required/) value.
+[`required`][required], or give it a [`default`][default] value.
 
-Like [other option groups](/documenting/#grouping-options-in-help), you can specify a `name` and
+Like [other option groups][grouping-options-in-help], you can specify a `name` and
 `help` text for the group if you want to set the group apart in the help output.
 
 ## Co-Occurring Option Groups
 
 Sometimes you have a set of options that only make sense when specified together. To enforce this,
-you can make an option group [`cooccurring`](api/clikt/com.github.ajalt.clikt.parameters.groups/cooccurring/).
+you can make an option group [`cooccurring`][cooccurring].
 
 Co-occurring groups must have at least one
-[`required`](api/clikt/com.github.ajalt.clikt.parameters.options/required/) option, and may also
+[`required`][required] option, and may also
 have non-required options. The `required` constraint is enforced if any of the options in the group
 are given on the command line. If none if the options are given, the value of the group is null.
 
@@ -480,16 +468,16 @@ Usage: tool [OPTIONS]
 Error: Missing option "--name".
 ```
 
-Like [other option groups](/documenting/#grouping-options-in-help), you can specify a `name` and
+Like [other option groups][grouping-options-in-help], you can specify a `name` and
 `help` text for the group if you want to set the group apart in the help output.
 
 ## Choice Options With Groups
 
-If you have different groups of options that only make sense when another option has a certain value, you can use 
-[`groupChoice`](api/clikt/com.github.ajalt.clikt.parameters.groups/group-choice/).
+If you have different groups of options that only make sense when another option has a certain value,
+you can use [`groupChoice`][groupChoice].
 
-These options are similar to [`choice` options](#choice-options), but instead of mapping a value to
-a single new type, they map a value to a [co-occurring `OptionGroup`](#co-occurring-option-groups).
+These options are similar to [`choice` options][choice-options], but instead of mapping a value to
+a single new type, they map a value to a [co-occurring `OptionGroup`][co-occurring-option-groups].
 Options for groups other than the selected one are ignored, and only the selected group's `required`
 constraints are enforced.
 
@@ -551,8 +539,7 @@ Error: Invalid value for "--load": invalid choice: whoops. (choose from disk, ne
 
 In some cases, you might want to create an option that uses the value
 given on the command line if there is one, but prompt the user for input
-if one is not provided. Clikt can take care of this for you with the
-[`prompt`](api/clikt/com.github.ajalt.clikt.parameters.options/prompt/) function.
+if one is not provided. Clikt can take care of this for you with the [`prompt`][prompt] function.
 
 ```kotlin tab="Example"
 class Hello : CliktCommand() {
@@ -575,8 +562,7 @@ Hello foo
 ```
 
 The default prompt string is based on the option name, but
-[`prompt`](api/clikt/com.github.ajalt.clikt.parameters.options/prompt/) takes a number of
-parameters to customize the output.
+[`prompt`][prompt] takes a number of parameters to customize the output.
 
 ## Password Prompts
 
@@ -610,7 +596,7 @@ associated with them, and they stop command line parsing as soon as
 they're encountered.
 
 The `--help` option is added automatically to commands, and `--version` can be added using
-[`versionOption`](api/clikt/com.github.ajalt.clikt.parameters.options/version-option/). Since
+[`versionOption`][versionOption]. Since
 the option doesn't have a value, you can't define it using a property delegate. Instead, call the
 function on a command directly, either in an `init` block, or on a command instance.
 
@@ -640,13 +626,13 @@ cli version 1.0
 ```
 
 If you want to define your own option with a similar behavior, you can do so by creating an instance
-of [`EagerOption`](api/clikt/com.github.ajalt.clikt.parameters.options/-eager-option/) and
+of [`EagerOption`][EagerOption] and
 passing it to
-[`CliktCommand.registerOption`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/register-option/).
+[`CliktCommand.registerOption`][CliktCommand.registerOption].
 `EagerOption`s have a `callback` that is called when the option is encountered on the command line.
 To print a message and halt execution normally from the callback, you can throw a
-[`PrintMessage`](api/clikt/com.github.ajalt.clikt.core/-print-message/) exception, and
-[`CliktCommand.main`](api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/) will take care
+[`PrintMessage`][PrintMessage] exception, and
+[`CliktCommand.main`][CliktCommand.main] will take care
 of printing the message.
 
 You can define your own version option like this:
@@ -665,7 +651,7 @@ class Cli : CliktCommand() {
 ## Deprecating Options
 
 You can communicate to users that an option is deprecated with
-[`option().deprecated()`](api/clikt/com.github.ajalt.clikt.parameters.options/deprecated/). By
+[`option().deprecated()`][deprecated]. By
 default, this function will add a tag to the option's help message, and print a warning to stderr if
 the option is used.
 
@@ -731,7 +717,7 @@ you can set the name manually for an option, or you can enable automatic
 envvar name inference.
 
 To set the envvar name manually, pass the name to
-[`option`](api/clikt/com.github.ajalt.clikt.parameters.options/option/):
+[`option`][option]:
 
 ```kotlin tab="Example"
 class Hello : CliktCommand() {
@@ -755,9 +741,9 @@ Hello Bar
 ```
 
 You can enable automatic envvar name inference by setting the `autoEnvvarPrefix` on a command's
-[`context`](api/clikt/com.github.ajalt.clikt.core/context/). This will cause all options without
+[`context`][context]. This will cause all options without
 an explicit envvar name to be given an uppercase underscore-separated envvar name. Since the prefix
-is set on the [`context`](api/clikt/com.github.ajalt.clikt.core/context/), it is propagated to
+is set on the [`context`][context], it is propagated to
 subcommands. If you have a a subcommand called `foo` with an option `--bar`, and your prefix is
 `MY_TOOL`, the option's envvar name will be `MY_TOOL_FOO_BAR`.
 
@@ -783,9 +769,9 @@ Hello Foo
 
 You might need to allow users to specify multiple values for an option in a single environment
 variable. You can do this by creating an option with
-[`multiple`](api/clikt/com.github.ajalt.clikt.parameters.options/multiple/). The environment
+[`multiple`][multiple]. The environment
 variable's value will be split according a regex, which defaults to split on whitespace for most
-types. [`file`](api/clikt/com.github.ajalt.clikt.parameters.types/file/) will change the pattern
+types. [`file`][file] will change the pattern
 to split according to the operating system's path splitting rules. On Windows, it will split on
 semicolons (`;`). On other systems, it will split on colons (`:`). You can also specify a split
 pattern by passing it to the `envvarSplit` parameter of `option`.
@@ -850,21 +836,18 @@ option names manually.
 
 ## Option Transformation Order
 
-Clikt has a large number of extension functions that can modify options. When applying multiple
-functions to the same option, there's only one valid order for the functions to be applied. For
-example, `option().default(3).int()` will not compile, because
-[`default`](api/clikt/com.github.ajalt.clikt.parameters.options/default/) must be applied after
-the value type conversion. Similarly, you can only apply one transform of each type. So
-`option().int().float()` is invalid since
-[`int`](api/clikt/com.github.ajalt.clikt.parameters.types/int/) and
-[`float`](api/clikt/com.github.ajalt.clikt.parameters.types/float/) both change the value type,
-as is `option().default("").multiple()` since
-[`default`](api/clikt/com.github.ajalt.clikt.parameters.options/default/) and
-[`multiple`](api/clikt/com.github.ajalt.clikt.parameters.options/multiple/) both transform the
+Clikt has a large number of extension functions that can modify options.
+When applying multiple functions to the same option,
+there's only one valid order for the functions to be applied.
+For example, `option().default(3).int()` will not compile,
+because [`default`][default] must be applied after the value type conversion.
+Similarly, you can only apply one transform of each type.
+So `option().int().float()` is invalid since [`int`][int] and [`float`][float]
+both change the value type, as is `option().default("").multiple()`
+since [`default`][default] and [`multiple`][multiple] both transform the
 call list (if you need a custom default value for `multiple`, you can pass it one as an argument).
 
-Here's an integer option with one of each available transform in a valid
-order:
+Here's an integer option with one of each available transform in a valid order:
 
 ```kotlin
 val opt: Pair<Int, Int> by option("-o", "--opt")
@@ -874,3 +857,42 @@ val opt: Pair<Int, Int> by option("-o", "--opt")
         .default(1 to 2)
         .validate { require(it.second % 2 == 0) }
 ```
+
+
+[option]:                      ../api/clikt/com.github.ajalt.clikt.parameters.options/option/
+[int]:                         ../api/clikt/com.github.ajalt.clikt.parameters.types/int/
+[choice]:                      ../api/clikt/com.github.ajalt.clikt.parameters.types/choice/
+[convert]:                     ../api/clikt/com.github.ajalt.clikt.parameters.options/convert/
+[parameter-types]:             ../parameters/#parameter-types
+[pair]:                        ../api/clikt/com.github.ajalt.clikt.parameters.options/pair/
+[triple]:                      ../api/clikt/com.github.ajalt.clikt.parameters.options/triple/
+[transformValues]:             ../api/clikt/com.github.ajalt.clikt.parameters.options/transform-values/
+[default]:                     ../api/clikt/com.github.ajalt.clikt.parameters.options/default/
+[multiple]:                    ../api/clikt/com.github.ajalt.clikt.parameters.options/multiple/
+[defaultLazy]:                 ../api/clikt/com.github.ajalt.clikt.parameters.options/default-lazy/
+[split]:                       ../api/clikt/com.github.ajalt.clikt.parameters.options/split/
+[flag]:                        ../api/clikt/com.github.ajalt.clikt.parameters.options/flag/
+[counted]:                     ../api/clikt/com.github.ajalt.clikt.parameters.options/counted/
+[switch]:                      ../api/clikt/com.github.ajalt.clikt.parameters.options/switch/
+[choice-options]:              #choice-options
+[feature-switch-flags]:        #feature-switch-flags
+[mutuallyExclusiveOptions]:    ../api/clikt/com.github.ajalt.clikt.parameters.groups/mutually-exclusive-options/
+[single]:                      ../api/clikt/com.github.ajalt.clikt.parameters.groups/single/
+[required]:                    ../api/clikt/com.github.ajalt.clikt.parameters.groups/required/
+[default]:                     ../api/clikt/com.github.ajalt.clikt.parameters.groups/required/
+[grouping-options-in-help]:    ../documenting/#grouping-options-in-help
+[cooccurring]:                 ../api/clikt/com.github.ajalt.clikt.parameters.groups/cooccurring/
+[required]:                    ../api/clikt/com.github.ajalt.clikt.parameters.options/required/
+[groupChoice]:                 ../api/clikt/com.github.ajalt.clikt.parameters.groups/group-choice/
+[choice-options]:              #choice-options
+[co-occurring-option-groups]:  #co-occurring-option-groups
+[prompt]:                      ../api/clikt/com.github.ajalt.clikt.parameters.options/prompt/
+[versionOption]:               ../api/clikt/com.github.ajalt.clikt.parameters.options/version-option/
+[EagerOption]:                 ../api/clikt/com.github.ajalt.clikt.parameters.options/-eager-option/
+[CliktCommand.registerOption]: ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/register-option/
+[PrintMessage]:                ../api/clikt/com.github.ajalt.clikt.core/-print-message/
+[CliktCommand.main]:           ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/
+[deprecated]:                  ../api/clikt/com.github.ajalt.clikt.parameters.options/deprecated/
+[context]:                     ../api/clikt/com.github.ajalt.clikt.core/context/
+[file]:                        ../api/clikt/com.github.ajalt.clikt.parameters.types/file/
+[float]:                       ../api/clikt/com.github.ajalt.clikt.parameters.types/float/

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -72,20 +72,20 @@ val arg: Int by argument(help="an argument").int()
 There are a number of built in types that can be applied to options and
 arguments.
 
-* `Int`: [`option().int()` and `argument().int()`](api/clikt/com.github.ajalt.clikt.parameters.types/int/)
-* `Long`: [`option().long()` and `argument().long()`](api/clikt/com.github.ajalt.clikt.parameters.types/long/)
+* `Int`: [`option().int()` and `argument().int()`][int]
+* `Long`: [`option().long()` and `argument().long()`][long]
 
-  By default, any value that fits in the integer type is accepted. You
-  can restrict the values to a range with [`restrictTo()`](api/clikt/com.github.ajalt.clikt.parameters.types/restrict-to/), which
-  allows you to either clamp the input to the range, or fail with an
-  error if the input is outside the range.
+  By default, any value that fits in the integer type is accepted.
+  You can restrict the values to a range with [`restrictTo()`][restrictTo],
+  which allows you to either clamp the input to the range,
+  or fail with an error if the input is outside the range.
 
-* `Float`: [`option().float()` and `argument().float()`](api/clikt/com.github.ajalt.clikt.parameters.types/float/)
-* `Double`: [`option().double()` and `argument().double()`](api/clikt/com.github.ajalt.clikt.parameters.types/double/)
+* `Float`: [`option().float()` and `argument().float()`][float]
+* `Double`: [`option().double()` and `argument().double()`][double]
 
-  As with integers, you can restrict the input to a range with [`restrictTo()`](api/clikt/com.github.ajalt.clikt.parameters.types/restrict-to/).
+  As with integers, you can restrict the input to a range with [`restrictTo()`][restrictTo].
 
-* [`option().choice()` and `argument().choice()`](api/clikt/com.github.ajalt.clikt.parameters.types/choice/)
+* [`option().choice()` and `argument().choice()`][choice]
 
   You can restrict the values to a set of values, and optionally map the
   input to a new value. For example, to create an option that only
@@ -103,8 +103,8 @@ arguments.
   val color: Color by argument().choice("RED" to Color.RED, "GREEN" to Color.GREEN)
  ```
 
-* `File`: [`option().file()` and `argument().file()`](api/clikt/com.github.ajalt.clikt.parameters.types/file/)
-* `Path`: [`option().path()` and `argument().path()`](api/clikt/com.github.ajalt.clikt.parameters.types/path/)
+* `File`: [`option().file()` and `argument().file()`][file]
+* `Path`: [`option().path()` and `argument().path()`][path]
 
   These conversion functions take extra parameters that allow you to
   require that values are file paths that have certain attributes, such
@@ -113,11 +113,10 @@ arguments.
 ## Custom Types
 
 You can convert parameter values to a custom type by using
-[`argument().convert()`](api/clikt/com.github.ajalt.clikt.parameters.arguments/convert/) and
-[`option().convert()`](api/clikt/com.github.ajalt.clikt.parameters.options/convert/). These
-functions take a lambda that converts the input `String` to any type. If the parameter takes
-multiple values, or an option appears multiple times in `argv`, the conversion lambda is called once
-for each value.
+[`argument().convert()`][convert] and [`option().convert()`][convert].
+These functions take a lambda that converts the input `String` to any type.
+If the parameter takes multiple values, or an option appears multiple times in `argv`,
+the conversion lambda is called once for each value.
 
 Any errors that are thrown from the lambda are automatically caught and
 a usage message is printed to the user. If you need to trigger
@@ -145,10 +144,9 @@ Usage: cli [OPTIONS]
 Error: Invalid value for "--opt": For input string: "foo"
 ```
 
-You can also pass
-[`option().convert()`](api/clikt/com.github.ajalt.clikt.parameters.options/convert/) a metavar
-that will be printed in the help page instead of the default of `VALUE`. We can modify the above
-example to use a metavar and an explicit error message:
+You can also pass [`option().convert()`][convert] a metavar
+that will be printed in the help page instead of the default of `VALUE`.
+We can modify the above example to use a metavar and an explicit error message:
 
 ```kotlin tab="Example"
 class Cli: CliktCommand() {
@@ -178,8 +176,7 @@ Options:
 ## Parameter Validation
 
 After converting a value to a new type, you can perform additional validation on the converted value
-with [`option().validate()`](api/clikt/com.github.ajalt.clikt.parameters.options/validate/) and
-[`argument().validate()`](api/clikt/com.github.ajalt.clikt.parameters.arguments/validate/).
+with [`option().validate()`][validate] and [`argument().validate()`][validate].
 `validate` takes a lambda that returns nothing, but can call `fail("error message")` if the value is
 invalid. You can also call `require()`, which will fail if the provided expression is false. The
 lambda is only called if the value is non-null.
@@ -219,3 +216,15 @@ Usage: tool [OPTIONS]
 
 Error: --bigger-number must be bigger than --number
 ```
+
+
+[int]:        ../api/clikt/com.github.ajalt.clikt.parameters.types/int/
+[long]:       ../api/clikt/com.github.ajalt.clikt.parameters.types/long/
+[restrictTo]: ../api/clikt/com.github.ajalt.clikt.parameters.types/restrict-to/
+[float]:      ../api/clikt/com.github.ajalt.clikt.parameters.types/float/
+[double]:     ../api/clikt/com.github.ajalt.clikt.parameters.types/double/
+[choice]:     ../api/clikt/com.github.ajalt.clikt.parameters.types/choice/
+[file]:       ../api/clikt/com.github.ajalt.clikt.parameters.types/file/
+[path]:       ../api/clikt/com.github.ajalt.clikt.parameters.types/path/
+[convert]:    ../api/clikt/com.github.ajalt.clikt.parameters.options/convert/
+[validate]:   ../api/clikt/com.github.ajalt.clikt.parameters.options/validate/

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,13 +1,13 @@
 # Quick Start
 
 You can get the library using any maven-compatible build system.
-Installation instructions can be found in the [README](https://github.com/ajalt/clikt).
+Installation instructions can be found in the [README][README].
 
 ## Basic Concepts
 
 Clikt command line interfaces are created by using property delegates
-inside of a [CliktCommmand](api/clikt/com.github.ajalt.clikt.core/-clikt-command/). The normal way to use Clikt is to forward
-`argv` from your `main` function to [ClktCommand.main](api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/).
+inside of a [CliktCommmand][CliktCommmand]. The normal way to use Clikt is to forward
+`argv` from your `main` function to [CliktCommand.main][main].
 
 The simplest command with no parameters would look like this:
 
@@ -40,10 +40,9 @@ Options:
 
 ## Printing to Stdout and Stderr
 
-Why does this example use [echo](api/clikt/com.github.ajalt.clikt.core/-clikt-command/echo/) instead of
-[println](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/println.html)?
+Why does this example use [echo][echo] instead of [println][println]?
 Although `println` works, it can cause problems with multi-platform
-support. [echo](api/clikt/com.github.ajalt.clikt.output/-term-ui/echo/) automatically translates line breaks into the line
+support. [echo][echo] automatically translates line breaks into the line
 separator for the current platform. So you don't have to worry that some
 of your users will see mangled output because you didn't test on
 Windows. You can also pass `err=true` to `echo` to print to stderr
@@ -97,8 +96,7 @@ Commands:
 
 ## Adding Parameters
 
-To add parameters, use the [option](api/clikt/com.github.ajalt.clikt.parameters.options/option/)
-and [argument](api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/) property
+To add parameters, use the [option][option] and [argument][argument] property
 delegates:
 
 ```kotlin tab="Example"
@@ -126,12 +124,10 @@ Options:
 ## Developing Command Line Applications With Gradle
 
 When you write a command line application, you probably want to be able to run it without invoking
-`java -jar ...` every time. If you're using Gradle, the [application
-plugin](https://docs.gradle.org/current/userguide/application_plugin.html) provides a gradle task
+`java -jar ...` every time. If you're using Gradle, the [application plugin][application_plugin] provides a gradle task
 that bundles your program jars and scripts to launch them. It makes it easy to build a zip or
 tarball that you can distribute to your users without them needing to perform any incatations like
-setting up a classpath. You can see this plugin in use the in [Clikt
-samples](https://github.com/ajalt/clikt/tree/master/samples).
+setting up a classpath. You can see this plugin in use the in [Clikt samples][clikt-samples].
 
 The application plugin also creates tasks that will build then run your
 main function directly from within gradle. Although it seems like these
@@ -146,5 +142,16 @@ make the run task mostly useless for command line applications.
 An easier way to do development is to used the `installDist` task
 provided by the plugin. This builds all the distribution scripts in your
 build folder, which you can then execute normally. See Clikt's
-[runsample](https://github.com/ajalt/clikt/blob/master/runsample) script
-for an example of this approach.
+[runsample][runsample] script for an example of this approach.
+
+
+[README]:             https://github.com/ajalt/clikt
+[CliktCommmand]:      ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/
+[main]:               ../api/clikt/com.github.ajalt.clikt.core/-clikt-command/main/
+[println]:            https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/println.html
+[echo]:               ../api/clikt/com.github.ajalt.clikt.output/-term-ui/echo/
+[option]:             ../api/clikt/com.github.ajalt.clikt.parameters.options/option/
+[argument]:           ../api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/
+[application_plugin]: https://docs.gradle.org/current/userguide/application_plugin.html
+[clikt-samples]:      https://github.com/ajalt/clikt/tree/master/samples
+[runsample]:          https://github.com/ajalt/clikt/blob/master/runsample

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -7,8 +7,8 @@ commonly used in command line programs.
 ## Launching Editors
 
 If you need to ask users for multi-line input, or need to have the user edit a file, you can do so
-through [`TermUi.editText`](api/clikt/com.github.ajalt.clikt.output/-term-ui/edit-text/) and
-[`TermUi.editFile`](api/clikt/com.github.ajalt.clikt.output/-term-ui/edit-file/). These
+through [`TermUi.editText`][editText] and
+[`TermUi.editFile`][editFile]. These
 functions open the program defined in the `VISUAL` or `EDITOR` environment variables, or a sensible
 default if neither are defined. The functions return the edited text if the user saved their
 changes.
@@ -27,10 +27,10 @@ fun getCommitMessage(): String? {
 
 ## Input Prompts
 
-Options can [prompt for values automatically](options.md#prompting-for-input), but you can also do
-so manually with [`TermUi.prompt`](api/clikt/com.github.ajalt.clikt.output/-term-ui/prompt/). By
+Options can [prompt for values automatically][prompting-for-input], but you can also do
+so manually with [`TermUi.prompt`][prompt]. By
 default, it accepts any input string, but you can also pass in a conversion function. If the
-conversion raises a [`UsageError`](api/clikt/com.github.ajalt.clikt.core/-usage-error/),
+conversion raises a [`UsageError`][UsageError],
 the prompt will ask the user to enter a different value.
 
 ```kotlin
@@ -52,7 +52,7 @@ Twice your number is 22
 ## Confirmation Prompts
 
 You can also ask the user for a yes or no response with
-[`TermUi.confirm`](api/clikt/com.github.ajalt.clikt.output/-term-ui/confirm/):
+[`TermUi.confirm`][confirm]:
 
 ```kotlin
 if (TermUi.confirm("Continue?") == true) {
@@ -67,3 +67,10 @@ response, you can pass `abort=true`:
 TermUi.confirm("Continue?", abort=true)
 ```
 
+
+[editText]:            ../api/clikt/com.github.ajalt.clikt.output/-term-ui/edit-text/
+[editFile]:            ../api/clikt/com.github.ajalt.clikt.output/-term-ui/edit-file/
+[prompting-for-input]: ../options/#prompting-for-input
+[prompt]:              ../api/clikt/com.github.ajalt.clikt.output/-term-ui/prompt/
+[UsageError]:          ../api/clikt/com.github.ajalt.clikt.core/-usage-error/
+[confirm]:             ../api/clikt/com.github.ajalt.clikt.output/-term-ui/confirm/

--- a/docs/whyclikt.md
+++ b/docs/whyclikt.md
@@ -29,13 +29,11 @@ possible.
 ## Why not a Kotlin library like kotlin-argparse or kotlinx.cli?
 
 Clikt didn't invent the idea of a property delegate-based cli parser.
-JetBrains made [kotlinx.cli](https://github.com/Kotlin/kotlinx.cli),
-which is functional, but is more of a proof-of-concept than a production
-ready library.
+JetBrains made [kotlinx.cli][kotlinx.cli], which is functional,
+but is more of a proof-of-concept than a production ready library.
 
-[kotlin-argparser](https://github.com/xenomachina/kotlin-argparser)
-builds off of [kotlinx.cli](https://github.com/Kotlin/kotlinx.cli), and
-works well for simple cases. It's missing a lot of features that Clikt
+[kotlin-argparser][kotlin-argparser] builds off of [kotlinx.cli][kotlinx.cli],
+and works well for simple cases. It's missing a lot of features that Clikt
 has, but features can be added. Its real drawback is that it
 fundamentally does not support composition of commands or parameter
 values. The lack of subcommand support was already a non-starter, but
@@ -81,7 +79,7 @@ fun main(args: Array<String>) = Cli().main(args)
 
 Both work fine, although you may find Clikt more consistent and a bit
 less verbose. The differences become more pronounced once you try to do
-anything that isn't built in to [kotlin-argparser](https://github.com/xenomachina/kotlin-argparser).
+anything that isn't built in to [kotlin-argparser][kotlin-argparser].
 
 Maybe you need an option to take two values. Here's another example from
 the `kotlin-argparser` README showing how to do that:
@@ -104,9 +102,8 @@ class MyArgs(parser: ArgParser) {
 }
 ```
 
-Clikt has that functionality built in as
-[`option().pair()`](api/clikt/com.github.ajalt.clikt.parameters.options/pair/), but you could
-implement it yourself like this:
+Clikt has that functionality built in as [`option().pair()`][pair],
+but you could implement it yourself like this:
 
 ```kotlin
 class Cli : CliktCommand() {
@@ -122,7 +119,7 @@ creation of Clikt:
 * Its inheritance-based design means that supporting types, multiple values, and multiple option occurrences would require a combinatorial number of copies of the above code. With Clikt, these are all orthogonal.
 * You have to do all error checking yourself. The `argparser` example silently discards extra values, or copies the single value, rather than inform the user of the mistake. You could write more code to do so, but Clikt takes care of it for you.
 * Option name inference is not automatic, requiring you to wrap the delegate with yet another function.
-* Each delegate function has a different name, with no indication of whether its creating an option or positional argument. With Clikt, all options are created with [`option()`](api/clikt/com.github.ajalt.clikt.parameters.options/option/), and all arguments with [`argument()`](api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/).
+* Each delegate function has a different name, with no indication of whether its creating an option or positional argument. With Clikt, all options are created with [`option()`][option], and all arguments with [`argument()`][argument].
 
 Some of these problems can be solved by writing more code, and some
 can't. On the other hand, Clikt attempts to consistent, intuitive,
@@ -133,7 +130,7 @@ you to think about edge cases.
 
 There are a lot of command line libraries for Java. Most are verbose and
 not composable. One popular Java library that is usable from Kotlin is
-[JCommander](http://jcommander.org/).
+[JCommander][JCommander].
 
 JCommander uses annotations to define parameters, and reflection to set
 fields. This is functional for simple types, but defining your own types
@@ -157,3 +154,11 @@ number of values. You can't nest subcommands.
 
 JCommander is a great library if you're writing code in Java, but we can
 do much better with Kotlin.
+
+
+[kotlinx.cli]:      https://github.com/Kotlin/kotlinx.cli
+[kotlin-argparser]: https://github.com/xenomachina/kotlin-argparser
+[pair]:             ../api/clikt/com.github.ajalt.clikt.parameters.options/pair/
+[option]:           ../api/clikt/com.github.ajalt.clikt.parameters.options/option/
+[argument]:         ../api/clikt/com.github.ajalt.clikt.parameters.arguments/argument/
+[JCommander]:       http://jcommander.org/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,23 +37,23 @@ markdown_extensions:
 
 nav:
   - 'Quickstart':
-      - 'Basic Concepts': quickstart.md
+      - 'Basic Concepts': quickstart/
       - 'Printing to Stdout and Stderr': quickstart/#printing-to-stdout-and-stderr
       - 'Nesting Commands': quickstart/#nesting-commands
       - 'Adding Parameters': quickstart/#adding-parameters
       - 'Developing Command Line Applications With Gradle': quickstart/#developing-command-line-applications-with-gradle
   - 'Why Clikt?':
-      - 'Why not a Kotlin library like kotlin-argparse or kotlinx.cli?': whyclikt.md
+      - 'Why not a Kotlin library like kotlin-argparse or kotlinx.cli?': whyclikt/
       - 'Why not a Java library like JCommander?': whyclikt/#why-not-a-java-library-like-jcommander
   - 'Parameters':
-      - 'Differences': parameters.md
+      - 'Differences': parameters/
       - 'Parameter Names': parameters/#parameter-names
       - 'Parameter Types': parameters/#parameter-types
       - 'Built-In Types': parameters/#built-in-types
       - 'Custom Types': parameters/#custom-types
       - 'Parameter Validation': parameters/#parameter-validation
   - 'Options':
-      - 'Basic Options': options.md
+      - 'Basic Options': options/
       - 'Option Names': options/#option-names
       - 'Option Names': options/#option-names
       - 'Customizing Options': options/#customizing-options
@@ -75,11 +75,11 @@ nav:
       - 'Windows and Java-Style Option Prefixes': options/#windows-and-java-style-option-prefixes
       - 'Option Transformation Order': options/#option-transformation-order
   - 'Arguments':
-      - 'Basic Arguments': arguments.md
+      - 'Basic Arguments': arguments/
       - 'Variadic Arguments': arguments/#variadic-arguments
       - 'Option-Like Arguments': arguments/#option-like-arguments
   - 'Commands':
-      - 'Executing Nested Commands': commands.md
+      - 'Executing Nested Commands': commands/
       - 'Customizing Command Name': commands/#customizing-command-name
       - 'Passing Parameters': commands/#passing-parameters
       - 'Nested Handling And Contexts': commands/#nested-handling-and-contexts
@@ -88,28 +88,28 @@ nav:
       - 'Printing the Help Message When No Arguments Are Given': commands/#printing-the-help-message-when-no-arguments-are-given
       - 'Warnings and Other Messages': commands/#warnings-and-other-messages
   - 'Documenting Scripts':
-      - 'Help Texts': documenting.md
+      - 'Help Texts': documenting/
       - 'Subcommand Short Help': documenting/#subcommand-short-help
       - 'Help Option Customization': documenting/#help-option-customization
       - 'Default Values in Help': documenting/#default-values-in-help
       - 'Required Options in Help': documenting/#required-options-in-help
       - 'Grouping Options in Help': documenting/#grouping-options-in-help
   - 'Advanced Patterns':
-      - 'Command Aliases': advanced.md
+      - 'Command Aliases': advanced/
       - 'Token Normalization': advanced/#token-normalization
       - 'Replacing stdin and stdout': advanced/#replacing-stdin-and-stdout
       - 'Command Line Argument Files': advanced/#command-line-argument-files
   - 'Utilities':
-      - 'Launching Editors': utilities.md
+      - 'Launching Editors': utilities/
       - 'Input Prompts': utilities/#input-prompts
       - 'Confirmation Prompts': utilities/#confirmation-prompts
   - 'Bash Autocomplete':
-      - 'Supported Functionality': autocomplete.md
+      - 'Supported Functionality': autocomplete/
       - 'Enabling Completion': autocomplete/#enabling-completion
       - 'Customizing Completions': autocomplete/#customizing-completions
       - 'Limitations': autocomplete/#limitations
   - 'Exception Handling':
-      - 'Where are Exceptions Handled?': exceptions.md
+      - 'Where are Exceptions Handled?': exceptions/
       - 'Handling Exceptions Manually': exceptions/#handling-exceptions-manually
       - 'Which Exceptions Exist?': exceptions/#which-exceptions-exist
   - 'API reference':


### PR DESCRIPTION
There are a lot of half-broken links in the documentation, e.g. consider page https://ajalt.github.io/clikt/quickstart/#basic-concepts -- link ["CliktCommand"](https://ajalt.github.io/clikt/quickstart/api/clikt/com.github.ajalt.clikt.core/-clikt-command/) leads to a 404 page (note the unnecessary `/quickstart/` part in the url, which may be removed to produce a valid api-docs page).
Internally, these links look like this: `[CliktCommmand](api/clikt/com.github.ajalt.clikt.core/-clikt-command/)`, inside [docs/quickstart.md](https://github.com/ajalt/clikt/blob/master/docs/quickstart.md) file. From the Markdown's point of view these relative links are quite valid, as they expand relatively the to the .md file containing them. However, the problem is that MkDocs translates your `quickstart.md` to a separate "folder" `quickstart/` (which is effectively equivalent to placing `quickstart.md` to the `quickstart/index.md`, which is then renders to `index.html`, which may be omitted in the URL - this is why you are able to visit pages like `.../quickstart/`). Since that, relative links expand to "wrong" paths, e.g. to `.../clikt/quickstart/api/...` instead of just `.../clikt/api/...`.

As one of possible solutions, in the proposed PR I've simply prepended all relative links (including cross-links to sibling doc chapters, not only to api) with `../`. **Note that this effectively breaks all links in Markdown**, i.e. links now lead to a Github's 404 page when raw docs files are viewed directly on Github.

Another solution is to use more explicit links by appending `.md` extension (in some cases `/index.md`) -- Markdown will treat such links simply as links to real files, while MkDocs will smartly convert them to proper URLs without these extensions. That is, link `api/.../-clikt-command/` will be written as `api/.../-clikt-command/index.md` and link `api/.../-clikt-command/main/` as `api/.../-clikt-command/main.md`. However, this approach is somewhat cumbersome, and also it suffers in the case when relative links have anchors (e.g. `parameters/#parameter-types` in `options.md`) -- in this case link `parameters.md#parameter-types` won't be handled properly by MkDocs, producing invalid `.../options/parameters.md/#parameter-types` URL.

Concluding, to my knowledge there is no way to make relative links work "properly" in all edge cases both with Markdown and with MkDocs. And since the documentation is more important than the Markdown preview on Github, it is preferable to fix the links in the docs first.

Additionally, I've replaced all inline links with reference-style links (specified at the bottom of each Markdown file), as it much simpler to play with them from one place.