### PR TITLE
Add spaces around `=` in README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Clikt has:
 
 ```kotlin
 class Hello : CliktCommand() {
-    val count: Int by option(help="Number of greetings").int().default(1)
-    val name: String by option(help="The person to greet").prompt("Your name")
+    val count: Int by option(help = "Number of greetings").int().default(1)
+    val name: String by option(help = "The person to greet").prompt("Your name")
 
     override fun run() {
         for (i in 1..count) {


### PR DESCRIPTION
That makes it match Kotlin official code style guide (and subjectively read better).