### PR TITLE
readme: implementation("group:nam:version")

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Clikt is distributed through
 
 ```groovy
 dependencies {
-   implementation 'com.github.ajalt:clikt:2.2.0'
+   implementation("com.github.ajalt:clikt:2.2.0")
 }
 ```
 


### PR DESCRIPTION
This syntax works for both Groovy (build.gradle) and Kotlin (build.gradle.kts) users