### PR TITLE
Split Editor#editorPath and pass it as program and arguments to ProcessBuilder()

### DIFF
--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/output/Editor.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/output/Editor.kt
@@ -36,14 +36,19 @@ internal class Editor(private val editorPath: String?,
         return "vi"
     }
 
+
+    private fun getEditorCommand(): Array<String> {
+        return getEditorPath().trim().split(" ").toTypedArray()
+    }
+
     fun editFile(filename: String) {
-        val editor = getEditorPath()
+        val editorCmd = getEditorCommand()
         try {
-            val process = ProcessBuilder(editor, filename).apply {
+            val process = ProcessBuilder(*editorCmd, filename).apply {
                 environment() += env
             }.start()
             val exitCode = process.waitFor()
-            if (exitCode != 0) throw CliktError("$editor: Editing failed!")
+            if (exitCode != 0) throw CliktError("${editorCmd[0]}: Editing failed!")
         } catch (err: Exception) {
             when (err) {
                 is CliktError -> throw err


### PR DESCRIPTION
ProcessBuilder searches for an executable file in the PATH withe exactly the name provided.
For strings like "atom --wait" this means it would e.g. in /bin search for a
"/bin/atom --wait" binary which does not exist.

This commit provides ProcessBuilder the program as the first item in an array. Options like
"--wait" together with the filename are provided as further array items. The above example
 "atom --wait" becomes ProcessBuilder("atom", "--wait", filename).

Fixes #97