### PR TITLE
Fix shell completion for commands with dashes in their name (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Shell completion can now handle command names with dashes. ([#104](https://github.com/ajalt/clikt/issues/104))
 
 ## [2.3.0] - 2019-11-07
 ### Added

--- a/clikt/src/main/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
+++ b/clikt/src/main/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
@@ -119,7 +119,7 @@ internal object CompletionGenerator {
             for (name in subcommands) {
                 append("""
                 |      $name)
-                |        ${funcName}_$name ${'$'}(( i + 1 ))
+                |        ${funcName}_${name.replace('-', '_')} ${'$'}(( i + 1 ))
                 |        return
                 |        ;;
                 |


### PR DESCRIPTION
Fixes #104 