### PR TITLE
Adding a HelpCommand to clikt

### DIFF
--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/HelpCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/HelpCommand.kt
@@ -1,0 +1,14 @@
+package com.github.ajalt.clikt.core
+
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.optional
+
+class HelpCommand : CliktCommand(name = "help", help = "Get help for a command") {
+  val name by argument("command").optional()
+
+  override fun run() {
+    val parent = currentContext.parent?.command ?: error("Register ${HelpCommand::class.simpleName}as a sub-command to some other command!")
+    val subcommand = parent._subcommands.firstOrNull { it.commandName == name }
+    throw PrintHelpMessage(subcommand ?: parent)
+  }
+}

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/HelpCommandTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/HelpCommandTest.kt
@@ -1,0 +1,38 @@
+package com.github.ajalt.clikt.core
+
+import com.github.ajalt.clikt.testing.TestCommand
+import io.kotest.assertions.throwables.shouldThrow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HelpCommandTest {
+  @Test
+  fun helpCommandWithoutCommand() {
+    val command = TestCommand().subcommands(HelpCommand(), TestCommand())
+    shouldThrow<PrintHelpMessage> {
+      command.parse(listOf("help"))
+      command.run()
+    }.apply {
+      assertEquals(this.command, command, "HelpCommand threw wrong print help")
+    }
+  }
+
+  @Test
+  fun helpCommandAsRootCommand() {
+    shouldThrow<IllegalStateException> {
+      HelpCommand().main(listOf())
+    }
+  }
+
+  @Test
+  fun helpCommandForSubcommand() {
+    val commandToPrintHelp = TestCommand(name = "test")
+    val command = TestCommand().subcommands(HelpCommand(), commandToPrintHelp)
+    shouldThrow<PrintHelpMessage> {
+      command.parse(listOf("help", "test"))
+      command.run()
+    }.apply {
+      assertEquals(this.command, commandToPrintHelp, "HelpCommand threw wrong print help")
+    }
+  }
+}

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -147,6 +147,8 @@ Options:
 If you don't want a help option to be added, you can set
 `helpOptionNames = emptySet()`
 
+If you want a help subcommand, like it is used in `git` or `systemctl`, you can add `HelpCommand()` as a subcommand.
+
 ## Default Values in Help
 
 You can configure the help formatter to show default values in the help output by passing


### PR DESCRIPTION
Closes #136 

Besides being useful in many situations, it is required as a built-in function, because `CliktCommand._subcommands` is marked `internal` and cannot be re-implemented easily.
Of course, if someone requires the functionality, he could build a second list of subcommands instead, so they don't need to access `_subcommands`.

Unfortunately, I could not find how to suppress the `--help` option on the `HelpCommand`.