### PR TITLE
Add {Input,Output}Stream support

### DIFF
--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/inputStream.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/inputStream.kt
@@ -1,0 +1,25 @@
+package com.github.ajalt.clikt.parameters.types
+
+import com.github.ajalt.clikt.completion.CompletionCandidates
+import com.github.ajalt.clikt.parameters.options.NullableOption
+import com.github.ajalt.clikt.parameters.options.OptionWithValues
+import com.github.ajalt.clikt.parameters.options.RawOption
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Paths
+
+fun RawOption.inputStream(): NullableOption<InputStream, InputStream> {
+    return convert("FILE", completionCandidates = CompletionCandidates.Path) {
+        if (it == "-") {
+            System.`in`
+        } else {
+            Files.newInputStream(Paths.get(it))
+        }
+    }
+}
+
+fun NullableOption<InputStream, InputStream>.defaultStdin(): OptionWithValues<InputStream, InputStream, InputStream> {
+    return default(System.`in`, "-")
+}

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
@@ -1,0 +1,25 @@
+package com.github.ajalt.clikt.parameters.types
+
+import com.github.ajalt.clikt.completion.CompletionCandidates
+import com.github.ajalt.clikt.parameters.options.NullableOption
+import com.github.ajalt.clikt.parameters.options.OptionWithValues
+import com.github.ajalt.clikt.parameters.options.RawOption
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import java.io.OutputStream
+import java.nio.file.Files
+import java.nio.file.Paths
+
+fun RawOption.outputStream(): NullableOption<OutputStream, OutputStream> {
+    return convert("FILE", completionCandidates = CompletionCandidates.Path) {
+        if (it == "-") {
+            System.out
+        } else {
+            Files.newOutputStream(Paths.get(it))
+        }
+    }
+}
+
+fun NullableOption<OutputStream, OutputStream>.defaultStdout(): OptionWithValues<OutputStream, OutputStream, OutputStream> {
+    return default(System.out, "-")
+}

--- a/samples/stream/README.md
+++ b/samples/stream/README.md
@@ -1,0 +1,9 @@
+# Stream sample
+
+This example demonstrates the ability to stream data using stdin.
+
+```
+$ echo 'hello world' > input.txt
+$ cat input.txt | ./runsample stream
+  md5sum: d41d8cd98f00b204e9800998ecf8427e
+```

--- a/samples/stream/build.gradle
+++ b/samples/stream/build.gradle
@@ -1,0 +1,1 @@
+mainClassName = 'com.github.ajalt.clikt.samples.stream.MainKt'

--- a/samples/stream/src/main/kotlin/com/github/ajalt/clikt/samples/stream/main.kt
+++ b/samples/stream/src/main/kotlin/com/github/ajalt/clikt/samples/stream/main.kt
@@ -1,0 +1,35 @@
+package com.github.ajalt.clikt.samples.stream
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.defaultStdin
+import com.github.ajalt.clikt.parameters.types.inputStream
+import java.security.DigestInputStream
+import java.security.MessageDigest
+
+class Md5Sum : CliktCommand(help = "Compute MD5 checksum") {
+
+    private val input by option().inputStream().defaultStdin()
+
+    override fun run() {
+        val digest = MessageDigest.getInstance("MD5")
+
+        DigestInputStream(input, digest).use { input ->
+            var read = input.read()
+
+            while (read != -1) {
+                read = input.read()
+            }
+        }
+
+        val hash = digest.digest()
+
+        val sum = hash.joinToString(separator = "") {
+            "%02x".format(it.toInt() and 0xFF)
+        }
+
+        echo("md5sum: $sum")
+    }
+}
+
+fun main(args: Array<String>) = Md5Sum().main(args)

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,5 @@ include 'samples:helpformat'
 include 'samples:ansicolors'
 include 'samples:plugins'
 include 'samples:json'
+include 'samples:stream'
 


### PR DESCRIPTION
This change adds support for [`InputStream`](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html) and [`OutputStream`](https://docs.oracle.com/javase/8/docs/api/java/io/OutputStream.html) options:

```kotlin
    private val input by option().inputStream().defaultStdin()
    private val output by option().outputStream().defaultStdout()
```

The option uses the `FILE` metavar and uses the Path completion candidates.

As is the [common convention](https://unix.stackexchange.com/questions/16357/usage-of-dash-in-place-of-a-filename) of many command-line tools, passing a hyphen (`-`) will serve as a substitute for stdin/stdout.

The sample demonstrates a reimplementation of the common `md5sum` utility:

```bash
$ echo 'hello world' > input.txt
$ cat input.txt | ./runsample stream
  md5sum: d41d8cd98f00b204e9800998ecf8427e
```
