### PR TITLE
Use '\n' as line separator if it is running in MinGW shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Update Kotlin to 1.3.71
+- Use '\n' as line separator if it is running in MinGW shell. ([#163](https://github.com/ajalt/clikt/pull/163))
 
 ## [2.6.0] - 2020-03-15
 ### Added

--- a/clikt/src/nativeMain/kotlin/com/github/ajalt/clikt/output/defaultCliktConsole.kt
+++ b/clikt/src/nativeMain/kotlin/com/github/ajalt/clikt/output/defaultCliktConsole.kt
@@ -1,6 +1,7 @@
 package com.github.ajalt.clikt.output
 
 import com.github.ajalt.clikt.mpp.isWindowsMpp
+import com.github.ajalt.clikt.mpp.readEnvvar
 import platform.posix.*
 
 actual fun defaultCliktConsole() = object : CliktConsole {
@@ -21,5 +22,9 @@ actual fun defaultCliktConsole() = object : CliktConsole {
         }
     }
 
-    override val lineSeparator get() = if (isWindowsMpp()) "\r\n" else "\n"
+    override val lineSeparator
+        get() = if (isWindowsMpp() && !isRunningInMingw()) "\r\n" else "\n"
+
+    private fun isRunningInMingw(): Boolean =
+            readEnvvar("OS") == "Windows_NT"
 }


### PR DESCRIPTION
Fixes #161.