### PR TITLE
Add metavar argument for int/float option extensions

### DIFF
--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
@@ -14,4 +14,4 @@ private fun valueToDouble(it: String): Double {
 fun RawArgument.double() = convert { valueToDouble(it) }
 
 /** Convert the option values to a `Double` */
-fun RawOption.double() = convert("FLOAT") { valueToDouble(it) }
+fun RawOption.double(metavar: String = "FLOAT") = convert(metavar) { valueToDouble(it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
+import kotlin.jvm.JvmOverloads
 
 private fun valueToDouble(it: String): Double {
     return it.toDoubleOrNull() ?: throw BadParameterValue("$it is not a valid floating point value")
@@ -14,4 +15,5 @@ private fun valueToDouble(it: String): Double {
 fun RawArgument.double() = convert { valueToDouble(it) }
 
 /** Convert the option values to a `Double` */
+@JvmOverloads
 fun RawOption.double(metavar: String = "FLOAT") = convert(metavar) { valueToDouble(it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
@@ -14,4 +14,4 @@ private fun valueToFloat(it: String): Float {
 fun RawArgument.float() = convert { valueToFloat(it) }
 
 /** Convert the option values to a `Float` */
-fun RawOption.float() = convert("FLOAT") { valueToFloat(it) }
+fun RawOption.float(metavar: String = "FLOAT") = convert(metavar) { valueToFloat(it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
+import kotlin.jvm.JvmOverloads
 
 private fun valueToFloat(it: String): Float {
     return it.toFloatOrNull() ?: throw BadParameterValue("$it is not a valid floating point value")
@@ -14,4 +15,5 @@ private fun valueToFloat(it: String): Float {
 fun RawArgument.float() = convert { valueToFloat(it) }
 
 /** Convert the option values to a `Float` */
+@JvmOverloads
 fun RawOption.float(metavar: String = "FLOAT") = convert(metavar) { valueToFloat(it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
@@ -14,4 +14,4 @@ internal fun valueToInt(it: String): Int {
 fun RawArgument.int() = convert { valueToInt(it) }
 
 /** Convert the option values to an `Int` */
-fun RawOption.int() = convert("INT") { valueToInt(it) }
+fun RawOption.int(metavar: String = "INT") = convert(metavar) { valueToInt(it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
+import kotlin.jvm.JvmOverloads
 
 internal fun valueToInt(it: String): Int {
     return it.toIntOrNull() ?: throw BadParameterValue("$it is not a valid integer")
@@ -14,4 +15,5 @@ internal fun valueToInt(it: String): Int {
 fun RawArgument.int() = convert { valueToInt(it) }
 
 /** Convert the option values to an `Int` */
+@JvmOverloads
 fun RawOption.int(metavar: String = "INT") = convert(metavar) { valueToInt(it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
+import kotlin.jvm.JvmOverloads
 
 internal fun valueToLong(it: String): Long {
     return it.toLongOrNull() ?: throw BadParameterValue("$it is not a valid integer")
@@ -14,4 +15,5 @@ internal fun valueToLong(it: String): Long {
 fun RawArgument.long() = convert { valueToLong(it) }
 
 /** Convert the option values to a `Long` */
+@JvmOverloads
 fun RawOption.long(metavar: String = "INT") = convert(metavar) { valueToLong(it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
@@ -14,4 +14,4 @@ internal fun valueToLong(it: String): Long {
 fun RawArgument.long() = convert { valueToLong(it) }
 
 /** Convert the option values to a `Long` */
-fun RawOption.long() = convert("INT") { valueToLong(it) }
+fun RawOption.long(metavar: String = "INT") = convert(metavar) { valueToLong(it) }


### PR DESCRIPTION
This PR adds the `metavar` argument for the option-creating extension functions `.int()`, `.float()`, `.double()` and `.long()`. This extensions have the hard-coded metavars `INT` and `FLOAT`, which cannot be customized, e.g. `<int>` or `<number-of-something>` might be preferable.

This PR should not break the backward source compatibility, since the old hard-coded values made default.