### PR TITLE
Add defaultForHelp argument for FlagOption.default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 - Clikt's JS target now supports both NodeJS and Browsers. ([#198](https://github.com/ajalt/clikt/issues/198))
-- Default values for switch options are now shown in the help. Help text can be customized using the `defaultForHelp` argument, similar to normal options.
+- Default values for switch options are now shown in the help. Help text can be customized using the `defaultForHelp` argument, similar to normal options. ([#205](https://github.com/ajalt/clikt/issues/205))
 
 ### Fixed
 - Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/198))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Clikt's JS target now supports both NodeJS and Browsers. ([#198](https://github.com/ajalt/clikt/issues/198))
+- Default values for flag options are now shown in the help. Help text can be customized using the `defaultForHelp` argument, similar to non-flag options.
 
 ### Fixed
 - Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/198))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 - Clikt's JS target now supports both NodeJS and Browsers. ([#198](https://github.com/ajalt/clikt/issues/198))
-- Default values for flag options are now shown in the help. Help text can be customized using the `defaultForHelp` argument, similar to non-flag options.
+- Default values for switch options are now shown in the help. Help text can be customized using the `defaultForHelp` argument, similar to normal options.
 
 ### Fixed
 - Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/198))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -104,7 +104,7 @@ class FlagOption<T>(
 fun RawOption.flag(
         vararg secondaryNames: String,
         default: Boolean = false,
-        defaultForHelp: String = default.toString()
+        defaultForHelp: String = ""
 ): FlagOption<Boolean> {
     val tags = helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
     return FlagOption(names, secondaryNames.toSet(), help, hidden, tags, envvar,

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -100,6 +100,8 @@ class FlagOption<T>(
  * @param secondaryNames additional names for that option that cause the option value to be false. It's good
  *   practice to provide secondary names so that users can disable an option that was previously enabled.
  * @param default the value for this property if the option is not given on the command line.
+ * @param defaultForHelp The help text for this option's default value if the help formatter is configured
+ *   to show them. By default, an empty string is being used to suppress the "default" help text.
  */
 fun RawOption.flag(
         vararg secondaryNames: String,
@@ -165,8 +167,8 @@ fun <T : Any> RawOption.switch(vararg choices: Pair<String, T>): FlagOption<T?> 
 /**
  * Set a default [value] for an option.
  *
- * @param defaultForHelp The help text for this option's default value if the help formatter is
- *   configured to show them, or null if the default value should not be shown.
+ * @param defaultForHelp The help text for this option's default value if the help formatter is configured
+ *   to show them. Use an empty string to suppress the "default" help text.
  */
 fun <T : Any> FlagOption<T?>.default(
         value: T,

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -101,8 +101,13 @@ class FlagOption<T>(
  *   practice to provide secondary names so that users can disable an option that was previously enabled.
  * @param default the value for this property if the option is not given on the command line.
  */
-fun RawOption.flag(vararg secondaryNames: String, default: Boolean = false): FlagOption<Boolean> {
-    return FlagOption(names, secondaryNames.toSet(), help, hidden, helpTags, envvar,
+fun RawOption.flag(
+        vararg secondaryNames: String,
+        default: Boolean = false,
+        defaultForHelp: String = default.toString()
+): FlagOption<Boolean> {
+    val tags = helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
+    return FlagOption(names, secondaryNames.toSet(), help, hidden, tags, envvar,
             transformEnvvar = {
                 when (it.toLowerCase()) {
                     "true", "t", "1", "yes", "y", "on" -> true

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -8,7 +8,6 @@ import com.github.ajalt.clikt.parameters.types.valueToInt
 import com.github.ajalt.clikt.parsers.FlagOptionParser
 import com.github.ajalt.clikt.parsers.OptionParser
 import com.github.ajalt.clikt.sources.ExperimentalValueSourceApi
-import kotlin.jvm.JvmOverloads
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -164,7 +163,6 @@ fun <T : Any> RawOption.switch(vararg choices: Pair<String, T>): FlagOption<T?> 
  * @param defaultForHelp The help text for this option's default value if the help formatter is
  *   configured to show them, or null if the default value should not be shown.
  */
-@JvmOverloads
 fun <T : Any> FlagOption<T?>.default(
         value: T,
         defaultForHelp: String = value.toString()

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -2,12 +2,14 @@ package com.github.ajalt.clikt.parameters.options
 
 import com.github.ajalt.clikt.core.*
 import com.github.ajalt.clikt.mpp.readEnvvar
+import com.github.ajalt.clikt.output.HelpFormatter
 import com.github.ajalt.clikt.parameters.groups.ParameterGroup
 import com.github.ajalt.clikt.parameters.internal.NullableLateinit
 import com.github.ajalt.clikt.parameters.types.valueToInt
 import com.github.ajalt.clikt.parsers.FlagOptionParser
 import com.github.ajalt.clikt.parsers.OptionParser
 import com.github.ajalt.clikt.sources.ExperimentalValueSourceApi
+import kotlin.jvm.JvmOverloads
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -157,12 +159,27 @@ fun <T : Any> RawOption.switch(choices: Map<String, T>): FlagOption<T?> {
  */
 fun <T : Any> RawOption.switch(vararg choices: Pair<String, T>): FlagOption<T?> = switch(mapOf(*choices))
 
-/** Set a default value for a option. */
-fun <T : Any> FlagOption<T?>.default(value: T): FlagOption<T> {
+/**
+ * Set a default [value] for an option.
+ *
+ * @param defaultForHelp The help text for this option's default value if the help formatter is
+ *   configured to show them, or null if the default value should not be shown.
+ */
+@JvmOverloads
+fun <T : Any> FlagOption<T?>.default(
+        value: T,
+        defaultForHelp: String? = null
+): FlagOption<T> {
+    val tags = if (defaultForHelp == null) {
+        helpTags
+    } else {
+        helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
+    }
     return copy(
             transformEnvvar = { transformEnvvar(it) ?: value },
             transformAll = { transformAll(it) ?: value },
-            validator = validator
+            validator = validator,
+            helpTags = tags
     )
 }
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -124,8 +124,11 @@ fun RawOption.flag(
 /**
  * Turn an option into a flag that counts the number of times the option occurs on the command line.
  */
-fun RawOption.counted(): FlagOption<Int> {
-    return FlagOption(names, emptySet(), help, hidden, helpTags, envvar,
+fun RawOption.counted(
+        defaultForHelp: String = ""
+): FlagOption<Int> {
+    val tags = helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
+    return FlagOption(names, emptySet(), help, hidden, tags, envvar,
             transformEnvvar = { valueToInt(it) },
             transformAll = { it.size },
             validator = {})

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -102,6 +102,14 @@ class FlagOption<T>(
  * @param default the value for this property if the option is not given on the command line.
  * @param defaultForHelp The help text for this option's default value if the help formatter is configured
  *   to show them. By default, an empty string is being used to suppress the "default" help text.
+ *
+ * ### Example:
+ *
+ * ```
+ * val flag by option(help = "flag option").flag("--no-flag", default = true, defaultForHelp = "enable")
+ * // Options:
+ * // --flag / --no-flag  flag option (default: enable)
+ * ```
  */
 fun RawOption.flag(
         vararg secondaryNames: String,

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -1,7 +1,6 @@
 package com.github.ajalt.clikt.parameters.options
 
 import com.github.ajalt.clikt.core.*
-import com.github.ajalt.clikt.mpp.readEnvvar
 import com.github.ajalt.clikt.output.HelpFormatter
 import com.github.ajalt.clikt.parameters.groups.ParameterGroup
 import com.github.ajalt.clikt.parameters.internal.NullableLateinit

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -167,13 +167,9 @@ fun <T : Any> RawOption.switch(vararg choices: Pair<String, T>): FlagOption<T?> 
 @JvmOverloads
 fun <T : Any> FlagOption<T?>.default(
         value: T,
-        defaultForHelp: String? = null
+        defaultForHelp: String = value.toString()
 ): FlagOption<T> {
-    val tags = if (defaultForHelp == null) {
-        helpTags
-    } else {
-        helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
-    }
+    val tags = helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
     return copy(
             transformEnvvar = { transformEnvvar(it) ?: value },
             transformAll = { transformAll(it) ?: value },

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -124,11 +124,8 @@ fun RawOption.flag(
 /**
  * Turn an option into a flag that counts the number of times the option occurs on the command line.
  */
-fun RawOption.counted(
-        defaultForHelp: String = ""
-): FlagOption<Int> {
-    val tags = helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
-    return FlagOption(names, emptySet(), help, hidden, tags, envvar,
+fun RawOption.counted(): FlagOption<Int> {
+    return FlagOption(names, emptySet(), help, hidden, helpTags, envvar,
             transformEnvvar = { valueToInt(it) },
             transformAll = { it.size },
             validator = {})

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
@@ -521,6 +521,7 @@ class CliktHelpFormatterTest {
             val foo by option(help = "foo option help").int().required()
             val bar by option("-b", "--bar", help = "bar option help", metavar = "META").default("optdef")
             val baz by option(help = "baz option help").flag("--no-baz")
+            val good by option(help = "good option help").flag("--bad", default = true, defaultForHelp = "good")
             val feature by option(help = "feature switch").switch("--one" to 1, "--two" to 2).default(0, defaultForHelp = "zero")
             val hidden by option(help = "hidden", hidden = true)
             val arg by argument()
@@ -586,7 +587,8 @@ class CliktHelpFormatterTest {
                 |Options:
                 |* --foo INT         foo option help (required)
                 |  -b, --bar META    bar option help (default: optdef)
-                |  --baz / --no-baz  baz option help
+                |  --baz / --no-baz  baz option help (default: false)
+                |  --good / --bad    good option help (default: good)
                 |  --one, --two      feature switch (default: zero)
                 |  -E, --eager2      this is an eager option
                 |  --version         Show the version and exit

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
@@ -587,7 +587,7 @@ class CliktHelpFormatterTest {
                 |Options:
                 |* --foo INT         foo option help (required)
                 |  -b, --bar META    bar option help (default: optdef)
-                |  --baz / --no-baz  baz option help (default: false)
+                |  --baz / --no-baz  baz option help
                 |  --good / --bad    good option help (default: good)
                 |  --one, --two      feature switch (default: zero)
                 |  -E, --eager2      this is an eager option

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
@@ -523,7 +523,6 @@ class CliktHelpFormatterTest {
             val baz by option(help = "baz option help").flag("--no-baz")
             val good by option(help = "good option help").flag("--bad", default = true, defaultForHelp = "good")
             val feature by option(help = "feature switch").switch("--one" to 1, "--two" to 2).default(0, defaultForHelp = "zero")
-            val verbosity by option("-v", help = "verbosity level").counted(defaultForHelp = "not verbose")
             val hidden by option(help = "hidden", hidden = true)
             val arg by argument()
             val multi by argument().multiple(required = true)
@@ -591,7 +590,6 @@ class CliktHelpFormatterTest {
                 |  --baz / --no-baz  baz option help
                 |  --good / --bad    good option help (default: good)
                 |  --one, --two      feature switch (default: zero)
-                |  -v                verbosity level (default: not verbose)
                 |  -E, --eager2      this is an eager option
                 |  --version         Show the version and exit
                 |  -h, --help        Show this message and exit

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
@@ -523,6 +523,7 @@ class CliktHelpFormatterTest {
             val baz by option(help = "baz option help").flag("--no-baz")
             val good by option(help = "good option help").flag("--bad", default = true, defaultForHelp = "good")
             val feature by option(help = "feature switch").switch("--one" to 1, "--two" to 2).default(0, defaultForHelp = "zero")
+            val verbosity by option("-v", help = "verbosity level").counted(defaultForHelp = "not verbose")
             val hidden by option(help = "hidden", hidden = true)
             val arg by argument()
             val multi by argument().multiple(required = true)
@@ -590,6 +591,7 @@ class CliktHelpFormatterTest {
                 |  --baz / --no-baz  baz option help
                 |  --good / --bad    good option help (default: good)
                 |  --one, --two      feature switch (default: zero)
+                |  -v                verbosity level (default: not verbose)
                 |  -E, --eager2      this is an eager option
                 |  --version         Show the version and exit
                 |  -h, --help        Show this message and exit

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
@@ -521,6 +521,7 @@ class CliktHelpFormatterTest {
             val foo by option(help = "foo option help").int().required()
             val bar by option("-b", "--bar", help = "bar option help", metavar = "META").default("optdef")
             val baz by option(help = "baz option help").flag("--no-baz")
+            val feature by option(help = "feature switch").switch("--one" to 1, "--two" to 2).default(0, defaultForHelp = "zero")
             val hidden by option(help = "hidden", hidden = true)
             val arg by argument()
             val multi by argument().multiple(required = true)
@@ -586,6 +587,7 @@ class CliktHelpFormatterTest {
                 |* --foo INT         foo option help (required)
                 |  -b, --bar META    bar option help (default: optdef)
                 |  --baz / --no-baz  baz option help
+                |  --one, --two      feature switch (default: zero)
                 |  -E, --eager2      this is an eager option
                 |  --version         Show the version and exit
                 |  -h, --help        Show this message and exit


### PR DESCRIPTION
This PR adds the `defaultForHelp` argument for the `FlagOption.default(value)` extension function.

---

Currently (2.8.0 release), flag options (neither non-nullable, nor nullable ones) do not display their default values in help messages (with `ClickHelpFormatter(showDefaultValues = true)`).

```Kotlin
val flag: Boolean by option(help = "Example flag")
    .switch("-y" to true, "-n" to false)
    .default(true)
// Options:
//   -y, -n      Example flag

```

It is possible to configure the `helpTags` manually to obtain the desired behavior:
```Kotlin
val flag: Boolean by option(
    help = "Example flag",
    helpTags = mapOf(HelpFormatter.Tags.DEFAULT to "yes")
).switch("-y" to true, "-n" to false).default(true)
// Options:
//   -y, -n      Example flag (default: yes)
```

But this is less convenient than the `defaultForHelp` argument available inside the `.default()` method for "normal" (non-flag) options:
```Kotlin
val x: Int by option(help = "Example option")
    .int()
    .default(42, defaultForHelp = "forty-two")
// Options:
//   --x INT     Example option (default: forty-two)
```

---

Note: this PR specifically addresses only the **nullable** flag options, which may be obtained via the `.switch()` construction:
```Kotlin
val nullableFlag: Boolean? by option().switch("-y" to true, "-n" to false)
// type of delegated property: FlagOption<Boolean?>
```

**Non-nullable** (Boolean) flag options require a different approach: their default values are specified in the `.flag()` "constructor", hence the `defaultForHelp` argument should be added to it.

---

Also, was it a deliberate decision not to show default values for flags? This PR uses the `null` default value for `defaultForHelp` arg in order to comply with the current behavior, but it would be nice to just use `defaultForHelp: String = value.toString()`.