### PR TITLE
Add FlagOption.convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Clikt's JS target now supports both NodeJS and Browsers. ([#198](https://github.com/ajalt/clikt/issues/198))
 - Default values for switch options are now shown in the help. Help text can be customized using the `defaultForHelp` argument, similar to normal options. ([#205](https://github.com/ajalt/clikt/issues/205))
+- Added `FlagOption.convert` ([#208](https://github.com/ajalt/clikt/issues/208))
 
 ### Fixed
 - Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/198))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Convert.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Convert.kt
@@ -13,9 +13,9 @@ import kotlin.jvm.JvmName
 /**
  * Convert the option's value type.
  *
- * The [conversion] is called once for each value in each invocation of the option. If any errors are thrown,
- * they are caught and a [BadParameterValue] is thrown with the error message. You can call `fail` to throw a
- * [BadParameterValue] manually.
+ * The [conversion] is called once for each value in each invocation of the option. If any errors
+ * are thrown, they are caught and a [BadParameterValue] is thrown with the error message. You can
+ * call [fail][OptionTransformContext.fail] to throw a [BadParameterValue] manually.
  *
  * You can call `convert` more than once to wrap the result of the previous `convert`, but it cannot
  * be called after [transformAll] (e.g. [multiple]) or [transformValues] (e.g. [pair]).

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
@@ -11,6 +11,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/core/ContextTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/core/ContextTest.kt
@@ -1,6 +1,7 @@
 package com.github.ajalt.clikt.core
 
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.beInstanceOf
 import io.kotest.matchers.should

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.parameters.options.counted
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/EagerOptionsTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/EagerOptionsTest.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.options.eagerOption
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/SubcommandTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/SubcommandTest.kt
@@ -10,6 +10,7 @@ import com.github.ajalt.clikt.parameters.arguments.pair
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
@@ -12,6 +12,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.validate
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import com.github.ajalt.clikt.testing.skipDueToKT33294
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/ChoiceTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/ChoiceTest.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/DoubleTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/DoubleTest.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/FloatTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/FloatTest.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/IntTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/IntTest.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/LongTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/LongTest.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/RangeTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/RangeTest.kt
@@ -5,6 +5,7 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.optional
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/sources/ChainedValueSourceTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/sources/ChainedValueSourceTest.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
 import com.github.ajalt.clikt.testing.TestSource
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.matchers.shouldBe
 import kotlin.js.JsName
 import kotlin.test.Test

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/testing/TestCommand.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/testing/TestCommand.kt
@@ -37,13 +37,8 @@ open class TestCommand(
 
     open fun run_() = Unit
 
-    fun parse(argv: String) {
-        parse(splitArgv(argv))
-        assertCalled(this)
-    }
-
     companion object {
-        private fun assertCalled(cmd: CliktCommand) {
+        fun assertCalled(cmd: CliktCommand) {
             if (cmd is TestCommand) {
                 if (cmd.count != null) {
                     assertEquals(cmd.count, cmd.actualCount, "command call count")
@@ -57,4 +52,10 @@ open class TestCommand(
             }
         }
     }
+}
+
+fun <T: TestCommand>T.parse(argv: String): T {
+    parse(splitArgv(argv))
+    TestCommand.assertCalled(this)
+    return this
 }

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/completion/CompletionTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/completion/CompletionTest.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.junit.Rule

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/EnvvarOptionsTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/EnvvarOptionsTest.kt
@@ -8,6 +8,7 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.sources.ExperimentalValueSourceApi
 import com.github.ajalt.clikt.testing.TestCommand
 import com.github.ajalt.clikt.testing.TestSource
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row
 import io.kotest.matchers.shouldBe

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/FileTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/FileTest.kt
@@ -3,6 +3,7 @@ package com.github.ajalt.clikt.parameters.types
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.matchers.types.shouldBeInstanceOf
 import java.io.File
 import kotlin.test.Test

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/InputStreamTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/InputStreamTest.kt
@@ -3,6 +3,7 @@ package com.github.ajalt.clikt.parameters.types
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import io.kotest.matchers.shouldBe

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/OutputStreamTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/OutputStreamTest.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.BadParameterValue
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import io.kotest.assertions.throwables.shouldThrow

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/PathTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/PathTest.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import io.kotest.assertions.throwables.shouldThrow

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parsers/ParserTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/parsers/ParserTest.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain

--- a/test/src/jvmTest/kotlin/com/github/ajalt/clikt/sources/PropertiesValueSourceTest.kt
+++ b/test/src/jvmTest/kotlin/com/github/ajalt/clikt/sources/PropertiesValueSourceTest.kt
@@ -10,6 +10,7 @@ import com.github.ajalt.clikt.parameters.types.double
 import com.github.ajalt.clikt.parameters.types.float
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row


### PR DESCRIPTION
The semantics of this are different from `OptionWithValues.convert`. The latter conversion is called one for each occurrence of the option on the command line, while this flag conversion uses `transformAll`, and so is only called once with the final value of the flag.

We could have added a `ValueTransformer` field to `FlagOption` to make the semantics match, but that wouldn't be backwards compatible. I don't think it makes much sense for flags to have a value transformer anyway; this design feels more intuitive.

Fixes #208