### PR TITLE
Show required multipled parameters as required in help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Added `FlagOption.convert` ([#208](https://github.com/ajalt/clikt/issues/208))
 
 ### Fixed
-- Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/198))
+- Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/202))
+- Options and Arguments with `multiple(required=true)` will now show as required in help output. ([#212](https://github.com/ajalt/clikt/issues/212))
 
 ## 2.8.0
 _2020-06-19_

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
@@ -132,7 +132,7 @@ class ProcessedArgument<AllT, ValueT>(
         get() = completionCandidatesWithDefault.value
 
     override val parameterHelp
-        get() = ParameterHelp.Argument(name, help, required && nvalues == 1 || nvalues > 1, nvalues < 0, helpTags)
+        get() = ParameterHelp.Argument(name, help, required || nvalues > 1, nvalues < 0, helpTags)
 
     override fun getValue(thisRef: CliktCommand, property: KProperty<*>): AllT = value
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/TransformAll.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/TransformAll.kt
@@ -125,7 +125,7 @@ fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.multiple(
         default: List<EachT> = emptyList(),
         required: Boolean = false
 ): OptionWithValues<List<EachT>, EachT, ValueT> {
-    return transformAll {
+    return transformAll(showAsRequired = required) {
         when {
             it.isEmpty() && required -> throw MissingParameter(option)
             it.isEmpty() && !required -> default


### PR DESCRIPTION
I don't remember why I originally wanted to show brackets around these arguments.

Fixes #212 
