### PR TITLE
Add help extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@
 - Default values for switch options are now shown in the help. Help text can be customized using the `defaultForHelp` argument, similar to normal options. ([#205](https://github.com/ajalt/clikt/issues/205))
 - Added `FlagOption.convert` ([#208](https://github.com/ajalt/clikt/issues/208))
 - Added ability to use unicode NEL character (`\u0085`) to manually break lines in help output ([#214](https://github.com/ajalt/clikt/issues/214))
+- Added `help("")` extension to options and arguments as an alternative to passing the help as an argument ([#207](https://github.com/ajalt/clikt/issues/207))
 
 ### Fixed
 - Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/202))
 - Options and Arguments with `multiple(required=true)` will now show as required in help output. ([#212](https://github.com/ajalt/clikt/issues/212))
 - Multiple short lines in a help text paragraph no longer appear dedented ([#215](https://github.com/ajalt/clikt/issues/215))
+
+### Changed
+- `Argument.help` and `Option.help` properties have been renamed to `argumentHelp` and `optionHelp`, respectively. The `help` parameter names to `option()` and `argument()` are unchanged.
+- `commandHelp` and `commandHelpEpilog` properties on `CliktCommand` are now `open`, so you can choose to override them instead of passing `help` and `epilog` to the constructor.
 
 ## 2.8.0
 _2020-06-19_

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
@@ -57,9 +57,29 @@ abstract class CliktCommand(
         internal val allowMultipleSubcommands: Boolean = false,
         internal val treatUnknownOptionsAsArgs: Boolean = false
 ) : ParameterHolder {
-    val commandName = name ?: inferCommandName()
-    val commandHelp = help
-    val commandHelpEpilog = epilog
+    /**
+     * The name of this command, used in help output.
+     *
+     * You can set this by passing `name` to the [CliktCommand] constructor.
+     */
+    val commandName: String = name ?: inferCommandName()
+
+    /**
+     * The help text for this command.
+     *
+     * You can set this by passing `help` to the [CliktCommand] constructor, or by overriding this
+     * property.
+     */
+    open val commandHelp: String = help
+
+    /**
+     * Help text to display at the end of the help output, after any parameters.
+     *
+     * You can set this by passing `epilog` to the [CliktCommand] constructor, or by overriding this
+     * property.
+     */
+    open val commandHelpEpilog: String = epilog
+
     internal var _subcommands: List<CliktCommand> = emptyList()
     internal val _options: MutableList<Option> = mutableListOf()
     internal val _arguments: MutableList<Argument> = mutableListOf()

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
@@ -38,7 +38,7 @@ interface Argument {
      *
      * It's usually better to leave this null and describe options in the usage line of the command instead.
      */
-    val help: String
+    val argumentHelp: String
 
     /** Extra information about this argument to pass to the help formatter. */
     val helpTags: Map<String, String>
@@ -113,7 +113,7 @@ class ProcessedArgument<AllT, ValueT>(
         name: String,
         override val nvalues: Int,
         override val required: Boolean,
-        override val help: String,
+        override val argumentHelp: String,
         override val helpTags: Map<String, String>,
         val completionCandidatesWithDefault: ValueWithDefault<CompletionCandidates>,
         val transformValue: ArgValueTransformer<ValueT>,
@@ -132,7 +132,7 @@ class ProcessedArgument<AllT, ValueT>(
         get() = completionCandidatesWithDefault.value
 
     override val parameterHelp
-        get() = ParameterHelp.Argument(name, help, required || nvalues > 1, nvalues < 0, helpTags)
+        get() = ParameterHelp.Argument(name, argumentHelp, required || nvalues > 1, nvalues < 0, helpTags)
 
     override fun getValue(thisRef: CliktCommand, property: KProperty<*>): AllT = value
 
@@ -160,7 +160,7 @@ class ProcessedArgument<AllT, ValueT>(
             name: String = this.name,
             nvalues: Int = this.nvalues,
             required: Boolean = this.required,
-            help: String = this.help,
+            help: String = this.argumentHelp,
             helpTags: Map<String, String> = this.helpTags,
             completionCandidatesWithDefault: ValueWithDefault<CompletionCandidates> = this.completionCandidatesWithDefault
     ): ProcessedArgument<AllT, ValueT> {
@@ -173,7 +173,7 @@ class ProcessedArgument<AllT, ValueT>(
             name: String = this.name,
             nvalues: Int = this.nvalues,
             required: Boolean = this.required,
-            help: String = this.help,
+            help: String = this.argumentHelp,
             helpTags: Map<String, String> = this.helpTags,
             completionCandidatesWithDefault: ValueWithDefault<CompletionCandidates> = this.completionCandidatesWithDefault
     ): ProcessedArgument<AllT, ValueT> {
@@ -211,7 +211,7 @@ fun CliktCommand.argument(
             name = name,
             nvalues = 1,
             required = true,
-            help = help,
+            argumentHelp = help,
             helpTags = helpTags,
             completionCandidatesWithDefault = ValueWithDefault(completionCandidates, CompletionCandidates.None),
             transformValue = { it },
@@ -223,8 +223,8 @@ fun CliktCommand.argument(
 /**
  * Set the help for this argument.
  *
- * Although you would normally pass the help string as an argument to [argument], this function can be
- * more convenient for long help strings.
+ * Although you would normally pass the help string as an argument to [argument], this function
+ * can be more convenient for long help strings.
  *
  * ### Example:
  *

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
@@ -221,6 +221,24 @@ fun CliktCommand.argument(
 }
 
 /**
+ * Set the help for this argument.
+ *
+ * Although you would normally pass the help string as an argument to [argument], this function can be
+ * more convenient for long help strings.
+ *
+ * ### Example:
+ *
+ * ```
+ * val number by argument()
+ *      .int()
+ *      .help("This is an argument that takes a number")
+ * ```
+ */
+fun <AllT, ValueT> ProcessedArgument<AllT, ValueT>.help(help: String): ProcessedArgument<AllT, ValueT> {
+    return copy(help = help)
+}
+
+/**
  * Transform all values to the final argument type.
  *
  * The input is a list of values, one for each value on the command line. The values in the

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/MutuallyExclusiveOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/MutuallyExclusiveOption.kt
@@ -56,6 +56,18 @@ class MutuallyExclusiveOptions<OptT : Any, OutT>(
         }
     }
 
+    /**
+     * Change the properties of this group.
+     *
+     * @param name  The name of the group, or null if parameters in the group should not be separated from other
+     *   parameters in the help output.
+     * @param help A help message to display for this group. If [name] is null, this parameter has
+     *   no effect.
+     */
+    fun copy(name: String? = groupName, help: String? = groupHelp): MutuallyExclusiveOptions<OptT, OutT> {
+        return MutuallyExclusiveOptions(options, name, help, transformAll)
+    }
+
     fun <T> copy(transformAll: (List<OptT>) -> T) = MutuallyExclusiveOptions(options, groupName, groupHelp, transformAll)
 }
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/MutuallyExclusiveOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/MutuallyExclusiveOption.kt
@@ -56,19 +56,20 @@ class MutuallyExclusiveOptions<OptT : Any, OutT>(
         }
     }
 
-    /**
-     * Change the properties of this group.
-     *
-     * @param name  The name of the group, or null if parameters in the group should not be separated from other
-     *   parameters in the help output.
-     * @param help A help message to display for this group. If [name] is null, this parameter has
-     *   no effect.
-     */
-    fun copy(name: String? = groupName, help: String? = groupHelp): MutuallyExclusiveOptions<OptT, OutT> {
-        return MutuallyExclusiveOptions(options, name, help, transformAll)
-    }
-
     fun <T> copy(transformAll: (List<OptT>) -> T) = MutuallyExclusiveOptions(options, groupName, groupHelp, transformAll)
+}
+
+/**
+ * Set the name and help for this option.
+ *
+ * Although you would normally pass the name and help strings as arguments to
+ * [mutuallyExclusiveOptions], this function can be more convenient for long help strings.
+ *
+ * @param name The name of the group.
+ * @param help A help message to display for this group.
+ */
+fun <OptT: Any, OutT> MutuallyExclusiveOptions<OptT, OutT>.help(name: String, help: String): MutuallyExclusiveOptions<OptT, OutT> {
+    return MutuallyExclusiveOptions(options, name, help, transformAll)
 }
 
 /**
@@ -89,6 +90,11 @@ class MutuallyExclusiveOptions<OptT : Any, OutT>(
  *   option("--oranges").int()
  * )
  * ```
+ *
+ * @param name If given, the options in this group will be grouped together under this value in the
+ * help output
+ * @param help If given, this text will be added in help output to the group. If [name] is null,
+ *   this value is not used.
  *
  * @see com.github.ajalt.clikt.parameters.options.switch
  * @see com.github.ajalt.clikt.parameters.types.choice

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/EagerOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/EagerOption.kt
@@ -16,7 +16,7 @@ import com.github.ajalt.clikt.parsers.OptionParser
 class EagerOption(
         override val names: Set<String>,
         override val nvalues: Int,
-        override val help: String,
+        override val optionHelp: String,
         override val hidden: Boolean,
         override val helpTags: Map<String, String>,
         override val groupName: String?,

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -135,6 +135,24 @@ fun RawOption.flag(
 }
 
 /**
+ * Set the help for this option.
+ *
+ * Although you would normally pass the help string as an argument to [option], this function can be
+ * more convenient for long help strings.
+ *
+ * ### Example:
+ *
+ * ```
+ * val number by option()
+ *      .flag()
+ *      .help("This option is a flag")
+ * ```
+ */
+fun <T> FlagOption<T>.help(help: String): FlagOption<T> {
+    return copy(help = help)
+}
+
+/**
  * Convert the option's value type.
  *
  * The [conversion] is called once with the final value of the option. If any errors are thrown,

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -26,7 +26,7 @@ typealias FlagConverter<InT, OutT> = OptionTransformContext.(InT) -> OutT
 class FlagOption<T>(
         names: Set<String>,
         override val secondaryNames: Set<String>,
-        override val help: String,
+        override val optionHelp: String,
         override val hidden: Boolean,
         override val helpTags: Map<String, String>,
         val envvar: String?,
@@ -75,7 +75,7 @@ class FlagOption<T>(
             validator: OptionValidator<T>,
             names: Set<String> = this.names,
             secondaryNames: Set<String> = this.secondaryNames,
-            help: String = this.help,
+            help: String = this.optionHelp,
             hidden: Boolean = this.hidden,
             helpTags: Map<String, String> = this.helpTags,
             envvar: String? = this.envvar
@@ -88,7 +88,7 @@ class FlagOption<T>(
             validator: OptionValidator<T> = this.validator,
             names: Set<String> = this.names,
             secondaryNames: Set<String> = this.secondaryNames,
-            help: String = this.help,
+            help: String = this.optionHelp,
             hidden: Boolean = this.hidden,
             helpTags: Map<String, String> = this.helpTags,
             envvar: String? = this.envvar
@@ -120,7 +120,7 @@ fun RawOption.flag(
         defaultForHelp: String = ""
 ): FlagOption<Boolean> {
     val tags = helpTags + mapOf(HelpFormatter.Tags.DEFAULT to defaultForHelp)
-    return FlagOption(names, secondaryNames.toSet(), help, hidden, tags, envvar,
+    return FlagOption(names, secondaryNames.toSet(), optionHelp, hidden, tags, envvar,
             transformEnvvar = {
                 when (it.toLowerCase()) {
                     "true", "t", "1", "yes", "y", "on" -> true
@@ -137,8 +137,8 @@ fun RawOption.flag(
 /**
  * Set the help for this option.
  *
- * Although you would normally pass the help string as an argument to [option], this function can be
- * more convenient for long help strings.
+ * Although you would normally pass the help string as an argument to [option], this function
+ * can be more convenient for long help strings.
  *
  * ### Example:
  *
@@ -197,7 +197,7 @@ inline fun <InT, OutT> FlagOption<InT>.convert(crossinline conversion: FlagConve
  * Turn an option into a flag that counts the number of times the option occurs on the command line.
  */
 fun RawOption.counted(): FlagOption<Int> {
-    return FlagOption(names, emptySet(), help, hidden, helpTags, envvar,
+    return FlagOption(names, emptySet(), optionHelp, hidden, helpTags, envvar,
             transformEnvvar = { valueToInt(it) },
             transformAll = { it.size },
             validator = {})
@@ -214,7 +214,7 @@ fun RawOption.counted(): FlagOption<Int> {
  */
 fun <T : Any> RawOption.switch(choices: Map<String, T>): FlagOption<T?> {
     require(choices.isNotEmpty()) { "Must specify at least one choice" }
-    return FlagOption(choices.keys, emptySet(), help, hidden, helpTags, null,
+    return FlagOption(choices.keys, emptySet(), optionHelp, hidden, helpTags, null,
             transformEnvvar = {
                 throw UsageError("environment variables not supported for switch options", this)
             },

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Option.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Option.kt
@@ -21,7 +21,7 @@ interface Option {
     val metavar: String?
 
     /** The description of this option, usually a single line. */
-    val help: String
+    val optionHelp: String
 
     /** The parser for this option's values. */
     val parser: OptionParser
@@ -48,7 +48,7 @@ interface Option {
     val parameterHelp: HelpFormatter.ParameterHelp.Option?
         get() = when {
             hidden -> null
-            else -> HelpFormatter.ParameterHelp.Option(names, secondaryNames, metavar, help, nvalues, helpTags,
+            else -> HelpFormatter.ParameterHelp.Option(names, secondaryNames, metavar, optionHelp, nvalues, helpTags,
                     groupName = (this as? StaticallyGroupedOption)?.groupName
                             ?: (this as? GroupableOption)?.parameterGroup?.groupName
             )

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
@@ -267,6 +267,24 @@ fun ParameterHolder.option(
 )
 
 /**
+ * Set the help for this option.
+ *
+ * Although you would normally pass the help string as an argument to [option], this function can be
+ * more convenient for long help strings.
+ *
+ * ### Example:
+ *
+ * ```
+ * val number by option()
+ *      .int()
+ *      .help("This is an option that takes a number")
+ * ```
+ */
+fun <AllT, EachT, ValueT> OptionWithValues<AllT, EachT, ValueT>.help(help: String): OptionWithValues<AllT, EachT, ValueT> {
+    return copy(help = help)
+}
+
+/**
  * Check the final option value and raise an error if it's not valid.
  *
  * The [validator] is called with the final option type (the output of [transformAll]), and should call `fail`

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
@@ -103,7 +103,7 @@ class OptionWithValues<AllT, EachT, ValueT>(
         names: Set<String>,
         val metavarWithDefault: ValueWithDefault<String?>,
         override val nvalues: Int,
-        override val help: String,
+        override val optionHelp: String,
         override val hidden: Boolean,
         override val helpTags: Map<String, String>,
         val envvar: String?,
@@ -172,7 +172,7 @@ class OptionWithValues<AllT, EachT, ValueT>(
             names: Set<String> = this.names,
             metavarWithDefault: ValueWithDefault<String?> = this.metavarWithDefault,
             nvalues: Int = this.nvalues,
-            help: String = this.help,
+            help: String = this.optionHelp,
             hidden: Boolean = this.hidden,
             helpTags: Map<String, String> = this.helpTags,
             envvar: String? = this.envvar,
@@ -192,7 +192,7 @@ class OptionWithValues<AllT, EachT, ValueT>(
             names: Set<String> = this.names,
             metavarWithDefault: ValueWithDefault<String?> = this.metavarWithDefault,
             nvalues: Int = this.nvalues,
-            help: String = this.help,
+            help: String = this.optionHelp,
             hidden: Boolean = this.hidden,
             helpTags: Map<String, String> = this.helpTags,
             envvar: String? = this.envvar,
@@ -252,7 +252,7 @@ fun ParameterHolder.option(
         names = names.toSet(),
         metavarWithDefault = ValueWithDefault(metavar, "TEXT"),
         nvalues = 1,
-        help = help,
+        optionHelp = help,
         hidden = hidden,
         helpTags = helpTags,
         envvar = envvar,
@@ -269,8 +269,8 @@ fun ParameterHolder.option(
 /**
  * Set the help for this option.
  *
- * Although you would normally pass the help string as an argument to [option], this function can be
- * more convenient for long help strings.
+ * Although you would normally pass the help string as an argument to [option], this function
+ * can be more convenient for long help strings.
  *
  * ### Example:
  *

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -11,6 +11,9 @@ and set it on the [command's context][customizing-contexts].
 argument, which is printed after the parameters and commands on the help page. All text is
 automatically trimmed of leading indentation and re-wrapped to the terminal width.
 
+As an alternative to passing your help strings as function arguments, you can also use the `help()`
+extensions for your options, and override `commandHelp` and `commandHelpEpilog` on your commands.
+
 ```kotlin tab="Example"
 class Hello : CliktCommand(help = """
     This script prints NAME COUNT times.
@@ -24,7 +27,21 @@ class Hello : CliktCommand(help = """
 }
 ```
 
-```text tab="Usage"
+```kotlin tab="Alternate style"
+class Hello : CliktCommand() {
+    override val commandHelp = """
+        This script prints NAME COUNT times.
+    
+        COUNT must be a positive number, and defaults to 1.
+    """
+    val count by option("-c", "--count", metavar="COUNT").int().default(1)
+        .help("number of greetings")
+    val name by argument()
+    override fun run() = repeat(count) { echo("Hello $name!") }
+}
+```
+
+```text tab="Help output"
 $ ./hello --help
 Usage: hello [OPTIONS] NAME
 

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
@@ -549,7 +549,8 @@ class CliktHelpFormatterTest {
             val g2 by G2().cooccurring()
             val ex by mutuallyExclusiveOptions(
                     option("--ex-foo", help = "exclusive foo"),
-                    option("--ex-bar", help = "exclusive bar"),
+                    option("--ex-bar", help = "exclusive bar")
+            ).copy(
                     name = "Exclusive",
                     help = "These options are exclusive"
             )
@@ -562,8 +563,8 @@ class CliktHelpFormatterTest {
             val foo by option(help = "foo option help").int().required()
             val bar by option("-b", "--bar", help = "bar option help", metavar = "META").default("optdef")
             val baz by option(help = "baz option help").flag("--no-baz")
-            val good by option(help = "good option help").flag("--bad", default = true, defaultForHelp = "good")
-            val feature by option(help = "feature switch").switch("--one" to 1, "--two" to 2).default(0, defaultForHelp = "zero")
+            val good by option().flag("--bad", default = true, defaultForHelp = "good").help("good option help")
+            val feature by option().switch("--one" to 1, "--two" to 2).default(0, defaultForHelp = "zero").help("feature switch")
             val hidden by option(help = "hidden", hidden = true)
             val multiOpt by option(help = "multiple").multiple(required = true)
             val arg by argument()
@@ -583,12 +584,13 @@ class CliktHelpFormatterTest {
             }
         }
 
-        class Sub : NoOpCliktCommand(help = """
+        class Sub : NoOpCliktCommand(helpTags = mapOf("deprecated" to "")) {
+            override val commandHelp: String = """
             a subcommand
 
             with extra help
-            """,
-                helpTags = mapOf("deprecated" to ""))
+            """
+        }
 
         class Sub2 : NoOpCliktCommand(help = "another command")
 

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatterTest.kt
@@ -550,7 +550,7 @@ class CliktHelpFormatterTest {
             val ex by mutuallyExclusiveOptions(
                     option("--ex-foo", help = "exclusive foo"),
                     option("--ex-bar", help = "exclusive bar")
-            ).copy(
+            ).help(
                     name = "Exclusive",
                     help = "These options are exclusive"
             )


### PR DESCRIPTION
As discussed in #207 and mentioned in #214, passing command and parameter help as function arguments is not always ideal, especially for longer help text.

For parameters, you can use `.copy(help="...")`, but this is undocumented, and doesn't apply to command help. It might be better to support this officially.

This PR adds `.help()` extensions to options and arguments, and makes `CliktCommand.commandHelp` open so that you can override it rather than passing the command's help to its constructor.

This allows you to write your help like this:

```kotlin
class Echo : CliktCommand() {
    override val commandHelp = "Echo the STRING(s) to standard output"

    val suppressNewline by option("-n").flag()
            .help("do not output the trailing newline")

    val strings by argument().multiple()
            .help("the strings to echo")
}
```

The problem with the current PR, and the reason this is a draft, is because properties named `help` already exist on the [`Argument`](https://ajalt.github.io/clikt/api/clikt/com.github.ajalt.clikt.parameters.arguments/-argument/help/) and [`Option`](https://ajalt.github.io/clikt/api/clikt/com.github.ajalt.clikt.parameters.options/-option/help/) intefraces. This means that it's easy to get a compile error if you don't manually import the extensions. This is the same problem that lead to #128.

So if we want to add this feature, here's some possible solutions:

1. Merge as-is and accept that people will run into this problem. I'm not a fan of this option.
2. Rename the new `help()` extensions to something like `withHelp()`, `setHelp()`, `optionHelp()`, `parameterHelp()` etc. This would work, but is a little uglier than the current names.
3. Rename the existing `help` properties to `optionHelp` and `argumentHelp` (or both to `parameterHelp`), similar to what we did with #128. This is obvously a breaking change that would have to be part of a major version bump, but would result in slightly cleaner function names. I doubt that many people access the `help` properties.

I'm curious to hear if you's use this feature, what solution/names you'd prefer.