### PR TITLE
Flush underlying stream when closing an UnclosableOutputStream

### DIFF
--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
@@ -111,6 +111,7 @@ private class UnclosableOutputStream(private var delegate: OutputStream?) : Outp
     override fun write(b: ByteArray, off: Int, len: Int) = stream.write(b, off, len)
     override fun flush() = stream.flush()
     override fun close() {
+        delegate?.flush()
         delegate = null
     }
 }


### PR DESCRIPTION
UnclosableOutputStream is used to wrap System.out when an OutputStream parameter is set to a hyphen.

In most classes that implement Closeable and Flushable, close() performs an implicit flush(). This includes PrintStreams like System.out and also the OutputStream implementation used for writing to files.

The user of an OutputStream parameter might expect a close() call to result in all of the bytes being flushed. This is true for writing to a file. However, it isn't true for writes to System.out, as UnclosableOutputStream doesn't flush() the underlying OutputStream on close().

Furthermore, the JVM doesn't flush System.out before it exits, resulting in commands that work when they write to a file but lose trailing buffered bytes when writing to stdout.

For consistency, I think it makes sense for UnclosableOutputStream to flush() the underlying stream on close().

As close() must be idempotent, this commit only calls flush() if the delegate has not already been set to null.