### PR TITLE
Add `check` extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added ability to use unicode NEL character (`\u0085`) to manually break lines in help output ([#214](https://github.com/ajalt/clikt/issues/214))
 - Added `help("")` extension to options and arguments as an alternative to passing the help as an argument ([#207](https://github.com/ajalt/clikt/issues/207))
 - Added `valueSourceKey` parameter to `option`
+- Added `check{}` extensions to options and arguments as an alternative to `validate`
 
 ### Fixed
 - Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/202))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/exceptions.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/exceptions.kt
@@ -110,8 +110,9 @@ open class BadParameterValue : UsageError {
     constructor(text: String, option: Option, context: Context? = null) : super(text, option, context)
 
     override fun formatMessage(): String {
-        if (inferParamName().isEmpty()) return "Invalid value: $text"
-        return "Invalid value for \"${inferParamName()}\": $text"
+        val error = if (text.isNullOrBlank()) "" else ": $text"
+        if (inferParamName().isEmpty()) return "Invalid value$error"
+        return "Invalid value for \"${inferParamName()}\"$error"
     }
 }
 

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
@@ -533,6 +533,27 @@ class OptionTest {
     }
 
     @Test
+    @JsName("option_check")
+    fun `option check`() = forAll(
+            row("--x=bar --y=foo --w=foo", "Invalid value for \"--x\": bar"),
+            row("--y=bar --w=foo", "Invalid value for \"--y\": bar"),
+            row("--y=foo --z=bar --w=foo", "Invalid value for \"--z\": fail bar"),
+            row("--y=foo --w=bar", "Invalid value for \"--w\": fail bar")
+    ) { argv, message ->
+        if (skipDueToKT33294) return@forAll
+
+        class C : TestCommand() {
+            val x by option().check { it == "foo" }
+            val y by option().required().check { it == "foo" }
+
+            val z by option().check(lazyMessage = { "fail $it" }) { it == "foo" }
+            val w by option().required().check(lazyMessage = { "fail $it" }) { it == "foo" }
+        }
+
+        shouldThrow<BadParameterValue> { C().parse(argv) }.message shouldBe message
+    }
+
+    @Test
     @JsName("option_validator_required")
     fun `option validator required`() {
         if (skipDueToKT33294) return

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
@@ -6,10 +6,7 @@ import com.github.ajalt.clikt.core.BadParameterValue
 import com.github.ajalt.clikt.core.MissingParameter
 import com.github.ajalt.clikt.core.MutuallyExclusiveGroupException
 import com.github.ajalt.clikt.core.UsageError
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.required
-import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.testing.TestCommand
 import com.github.ajalt.clikt.testing.parse
@@ -351,7 +348,7 @@ class OptionGroupsTest {
         }
 
         if (ec) C().parse(argv)
-        else shouldThrow<UsageError> { C().parse(argv) }.message shouldBe "fail"
+        else shouldThrow<BadParameterValue> { C().parse(argv) }.message shouldBe "Invalid value for \"--x\": fail"
     }
 
     @Test
@@ -360,14 +357,12 @@ class OptionGroupsTest {
             row("", null, true, null),
             row("--x=1 --y=1", 1, true, null),
             row("--x=2", null, false, "Missing option \"--y\"."),
-            row("--x=2 --y=1", null, false, "fail")
+            row("--x=2 --y=1", null, false, "Invalid value for \"--x\": fail")
     ) { argv, ex, ec, em ->
         if (skipDueToKT33294) return@forAll
 
         class G : OptionGroup() {
-            val x by option().int().validate {
-                require(it == 1) { "fail" }
-            }
+            val x by option().int().check("fail") { it == 1 }
             val y by option().required()
         }
 
@@ -407,7 +402,7 @@ class OptionGroupsTest {
             }
         }
         if (ec) C().parse(argv)
-        else shouldThrow<UsageError> { C().parse(argv) }.message shouldBe "fail"
+        else shouldThrow<UsageError> { C().parse(argv) }.message shouldBe "Invalid value for \"--y\": fail"
     }
 
     @Test

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -233,16 +233,49 @@ Your file contents: some text
 ## Parameter Validation
 
 After converting a value to a new type, you can perform additional validation on the converted value
-with [`option().validate()`][validate] and [`argument().validate()`][validate].
-`validate` takes a lambda that returns nothing, but can call `fail("error message")` if the value is
-invalid. You can also call `require()`, which will fail if the provided expression is false. The
-lambda is only called if the value is non-null.
+with [`check()`][checkOpt] and [`validate()`][validateOpt] (or the [argument][checkArg]
+[equivalents][validateArg]).
 
-```kotlin
-val opt by option().int().validate {
-    require(it % 2 == 0) { "value must be even" }
+### `check()`
+
+[`check()`][checkOpt] is similar the stdlib function of the [same name][checkKotlin]: it takes
+lambda that returns a boolean to indicate if the parameter value is valid or not, and reports an
+error if it returns false. The lambda is only called if the parameter value is non-null.
+
+```kotlin tab="Example"
+class Tool : CliktCommand() {
+    val number by option(help = "An even number").int()
+            .check("value must be even") { it % 2 == 0 }
+
+    override fun run() {
+        echo("number=$number")
+    }
 }
 ```
+
+```text tab="Usage 1"
+$ ./tool --number=2
+number=2
+```
+
+```text tab="Usage 2"
+$ ./tool
+number=null
+```
+
+```text tab="Usage 3"
+$ ./tool --number=1
+Usage: tool [OPTIONS]
+
+Error: invalid value for --number: value must be even
+```
+
+### `validate()`
+
+For more complex validation, you can use [`validate()`][validateOpt]. This function takes a lambda
+that returns nothing, but can call `fail("error message")` if the value is invalid. You can also
+call `require()`, which will fail if the provided expression is false. Like `check`, the lambda is
+only called if the value is non-null.
 
 The lambdas you pass to `validate` are called after the values for all options and arguments have
 been set, so (unlike in transforms) you can reference other parameters:
@@ -275,6 +308,9 @@ Error: --bigger-number must be bigger than --number
 ```
 
 
+[checkArg]:       api/clikt/com.github.ajalt.clikt.parameters.options/check.md
+[checkKotlin]:    https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/check.html
+[checkOpt]:       api/clikt/com.github.ajalt.clikt.parameters.options/check.md
 [choice]:         api/clikt/com.github.ajalt.clikt.parameters.types/choice.md
 [convert]:        api/clikt/com.github.ajalt.clikt.parameters.options/convert.md
 [defaultStdin]:   api/clikt/com.github.ajalt.clikt.parameters.types/default-stdin.md
@@ -289,4 +325,5 @@ Error: --bigger-number must be bigger than --number
 [outputStream]:   api/clikt/com.github.ajalt.clikt.parameters.types/output-stream.md
 [path]:           api/clikt/com.github.ajalt.clikt.parameters.types/path.md
 [restrictTo]:     api/clikt/com.github.ajalt.clikt.parameters.types/restrict-to.md
-[validate]:       api/clikt/com.github.ajalt.clikt.parameters.options/validate.md
+[validateArg]:    api/clikt/com.github.ajalt.clikt.parameters.options/validate.md
+[validateOpt]:    api/clikt/com.github.ajalt.clikt.parameters.options/validate.md

--- a/samples/validation/src/main/kotlin/com/github/ajalt/clikt/samples/validation/main.kt
+++ b/samples/validation/src/main/kotlin/com/github/ajalt/clikt/samples/validation/main.kt
@@ -3,10 +3,7 @@ package com.github.ajalt.clikt.samples.validation
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.convert
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.transformAll
-import com.github.ajalt.clikt.parameters.options.transformValues
-import com.github.ajalt.clikt.parameters.options.validate
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.int
 import java.net.URL
 
@@ -14,11 +11,7 @@ data class Quad(val a: Int, val b: Int, val c: Int, val d: Int)
 
 class Cli : CliktCommand(help = "Validation examples") {
     val count by option(help = "A positive even number").int()
-            .validate {
-                require(it > 0 && it % 2 == 0) {
-                    "Should be a positive, even integer"
-                }
-            }
+            .check("Should be a positive, even integer") { it > 0 && it % 2 == 0 }
 
     val biggerCount by option(help = "A number larger than --count").int()
             .validate {


### PR DESCRIPTION
Most uses of `validate` are a single call to `require`. To simplify this case, this PR adds `check` extensions that take a lambda returning a boolean.

These extensions are semantically more like the `require` functions from the stdlib than `check`, but since we already have extensions named `required`, I didn't want to add a name that's so similar.