### PR TITLE
Add localization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 ### Removed
 - Removed `envvarSplit` parameter from `option()` and `convert()`. Option values from environment variables are no longer split automatically. ([#177](https://github.com/ajalt/clikt/issues/177))
 - Removed public constructors from the following classes: `ProcessedArgument`, `OptionWithValues`, `FlagOption`, `CoOccurringOptionGroup`, `ChoiceGroup`, `MutuallyExclusiveOptions`.
-- `MissingParamter` exception replaced with `MissingOption` and `MissingArgument`
+- `MissingParameter` exception replaced with `MissingOption` and `MissingArgument`
 
 ### Deprecated
 - `@ExperimentalCompletionCandidates` and `@ExperimentalValueSourceApi` annotations. These APIs no longer require an opt-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added ability to use unicode NEL character (`\u0085`) to manually break lines in help output ([#214](https://github.com/ajalt/clikt/issues/214))
 - Added `help("")` extension to options and arguments as an alternative to passing the help as an argument ([#207](https://github.com/ajalt/clikt/issues/207))
 - Added `valueSourceKey` parameter to `option`
-- Added `check{}` extensions to options and arguments as an alternative to `validate`
+- Added `check()` extensions to options and arguments as an alternative to `validate()`
 - Added `prompt` and `confirm` functions to `CliktCommand` that call the `TermUi` equivalents with the current console.
 - Added `echo()` overload with no parameters to CliktCommand that prints a newline by itself.
 - Added localization support. You can set an implementation of the `Localization` interface on your context with your translations. ([#227](https://github.com/ajalt/clikt/issues/227))
@@ -24,6 +24,7 @@
 - `commandHelp` and `commandHelpEpilog` properties on `CliktCommand` are now `open`, so you can choose to override them instead of passing `help` and `epilog` to the constructor.
 - Replaced `MapValueSource.defaultKey` with `ValueSource.getKey()`, which is more customizable.
 - `Option.metavar`, `Option.parameterHelp`, `OptionGroup.parameterHelp` and `Argument.parameterHelp` properties are now functions.
+- Changed constructor parameters of `CliktHelpFormatter`. Added `localization` and removed `usageTitle`, `optionsTitle`, `argumentsTitle`, `commandsTitle`, `optionsMetavar`, and `commandMetavar`. Those strings are now defined on equivalently named functions on `Localization`.
 
 ### Removed
 - Removed `envvarSplit` parameter from `option()` and `convert()`. Option values from environment variables are no longer split automatically. ([#177](https://github.com/ajalt/clikt/issues/177))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Removed
 - Removed `envvarSplit` parameter from `option()` and `convert()`. Option values from environment variables are no longer split automatically. ([#177](https://github.com/ajalt/clikt/issues/177))
 - Removed public constructors from the following classes: `ProcessedArgument`, `OptionWithValues`, `FlagOption`, `CoOccurringOptionGroup`, `ChoiceGroup`, `MutuallyExclusiveOptions`.
+- `MissingParamter` exception replaced with `MissingOption` and `MissingArgument`
 
 ### Deprecated
 - `@ExperimentalCompletionCandidates` and `@ExperimentalValueSourceApi` annotations. These APIs no longer require an opt-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Removed `envvarSplit` parameter from `option()` and `convert()`. Option values from environment variables are no longer split automatically. ([#177](https://github.com/ajalt/clikt/issues/177))
 - Removed public constructors from the following classes: `ProcessedArgument`, `OptionWithValues`, `FlagOption`, `CoOccurringOptionGroup`, `ChoiceGroup`, `MutuallyExclusiveOptions`.
 - `MissingParameter` exception replaced with `MissingOption` and `MissingArgument`
+- Removed `Context.helpOptionMessage`. Override `Localization.helpOptionMessage` and set it on your context instead.
 
 ### Deprecated
 - `@ExperimentalCompletionCandidates` and `@ExperimentalValueSourceApi` annotations. These APIs no longer require an opt-in.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `check{}` extensions to options and arguments as an alternative to `validate`
 - Added `prompt` and `confirm` functions to `CliktCommand` that call the `TermUi` equivalents with the current console.
 - Added `echo()` overload with no parameters to CliktCommand that prints a newline by itself.
+- Added localization support. You can set an implementation of the `Localization` interface on your context with your translations. ([#227](https://github.com/ajalt/clikt/issues/227))
 
 ### Fixed
 - Hidden options will no longer be suggested as possible typo corrections. ([#202](https://github.com/ajalt/clikt/issues/202))
@@ -22,6 +23,7 @@
 - `Argument.help` and `Option.help` properties have been renamed to `argumentHelp` and `optionHelp`, respectively. The `help` parameter names to `option()` and `argument()` are unchanged.
 - `commandHelp` and `commandHelpEpilog` properties on `CliktCommand` are now `open`, so you can choose to override them instead of passing `help` and `epilog` to the constructor.
 - Replaced `MapValueSource.defaultKey` with `ValueSource.getKey()`, which is more customizable.
+- `Option.metavar`, `Option.parameterHelp`, `OptionGroup.parameterHelp` and `Argument.parameterHelp` properties are now functions.
 
 ### Removed
 - Removed `envvarSplit` parameter from `option()` and `convert()`. Option values from environment variables are no longer split automatically. ([#177](https://github.com/ajalt/clikt/issues/177))

--- a/clikt/build.gradle.kts
+++ b/clikt/build.gradle.kts
@@ -82,7 +82,6 @@ kotlin {
 
 tasks.withType<KotlinCompile>().all {
     kotlinOptions.jvmTarget = "1.8"
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=all"
 }
 
 val dokka by tasks.getting(DokkaTask::class) {

--- a/clikt/build.gradle.kts
+++ b/clikt/build.gradle.kts
@@ -82,6 +82,7 @@ kotlin {
 
 tasks.withType<KotlinCompile>().all {
     kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.freeCompilerArgs += "-Xjvm-default=all"
 }
 
 val dokka by tasks.getting(DokkaTask::class) {

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
@@ -102,7 +102,7 @@ abstract class CliktCommand(
 
         if (currentContext.helpOptionNames.isNotEmpty()) {
             val names = currentContext.helpOptionNames - registeredOptionNames()
-            if (names.isNotEmpty()) _options += helpOption(names, currentContext.helpOptionMessage)
+            if (names.isNotEmpty()) _options += helpOption(names, currentContext.localization.helpOptionMessage())
         }
 
         for (command in _subcommands) {

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
@@ -113,9 +113,9 @@ abstract class CliktCommand(
     }
 
     private fun allHelpParams(): List<ParameterHelp> {
-        return _options.mapNotNull { it.parameterHelp } +
-                _arguments.mapNotNull { it.parameterHelp } +
-                _groups.mapNotNull { it.parameterHelp } +
+        return _options.mapNotNull { it.parameterHelp(currentContext) } +
+                _arguments.mapNotNull { it.parameterHelp(currentContext) } +
+                _groups.mapNotNull { it.parameterHelp(currentContext) } +
                 _subcommands.map { ParameterHelp.Subcommand(it.commandName, it.shortHelp(), it.helpTags) }
     }
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
@@ -417,7 +417,7 @@ abstract class CliktCommand(
             echo(e.message, err = true)
             exitProcessMpp(1)
         } catch (e: Abort) {
-            echo("Aborted!", err = true)
+            echo(currentContext.localization.aborted(), err = true)
             exitProcessMpp(if (e.error) 1 else 0)
         }
     }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
@@ -4,7 +4,6 @@ import com.github.ajalt.clikt.output.*
 import com.github.ajalt.clikt.sources.ChainedValueSource
 import com.github.ajalt.clikt.sources.ValueSource
 import kotlin.properties.ReadOnlyProperty
-import kotlin.reflect.KProperty
 
 typealias TypoSuggestor = (enteredValue: String, possibleValues: List<String>) -> List<String>
 
@@ -24,7 +23,6 @@ typealias TypoSuggestor = (enteredValue: String, possibleValues: List<String>) -
  * @property helpOptionNames The names to use for the help option. If any names in the set conflict with other
  *   options, the conflicting name will not be used for the help option. If the set is empty, or contains no
  *   unique names, no help option will be added.
- * @property helpOptionMessage The description of the help option.
  * @property helpFormatter The help formatter for this command.
  * @property tokenTransformer An optional transformation function that is called to transform command line
  *   tokens (options and commands) before parsing. This can be used to implement e.g. case insensitive
@@ -43,7 +41,6 @@ class Context(
         val autoEnvvarPrefix: String?,
         val printExtraMessages: Boolean,
         val helpOptionNames: Set<String>,
-        val helpOptionMessage: String,
         val helpFormatter: HelpFormatter,
         val tokenTransformer: Context.(String) -> String,
         val console: CliktConsole,
@@ -115,9 +112,6 @@ class Context(
          * help option. If the set is empty, or contains no unique names, no help option will be added.
          */
         var helpOptionNames: Set<String> = parent?.helpOptionNames ?: setOf("-h", "--help")
-
-        /** The description of the help option, or `null` to use the default from the [localization]. */
-        var helpOptionMessage: String? = parent?.helpOptionMessage
 
         /** The help formatter for this command, or null to use the default */
         var helpFormatter: HelpFormatter? = parent?.helpFormatter
@@ -192,12 +186,10 @@ class Context(
                 val interspersed = allowInterspersedArgs && !command.allowMultipleSubcommands &&
                         parent?.let { p -> p.ancestors().any { it.command.allowMultipleSubcommands } } != true
                 val formatter = helpFormatter ?: CliktHelpFormatter(localization)
-                val helpMessage = helpOptionMessage ?: localization.helpOptionMessage()
                 return Context(
                         parent, command, interspersed, autoEnvvarPrefix, printExtraMessages,
-                        helpOptionNames, helpMessage, formatter, tokenTransformer,
-                        console, expandArgumentFiles, readEnvvarBeforeValueSource, valueSource,
-                        correctionSuggestor, localization
+                        helpOptionNames, formatter, tokenTransformer, console, expandArgumentFiles,
+                        readEnvvarBeforeValueSource, valueSource, correctionSuggestor, localization
                 )
             }
         }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
@@ -116,11 +116,11 @@ class Context(
          */
         var helpOptionNames: Set<String> = parent?.helpOptionNames ?: setOf("-h", "--help")
 
-        /** The description of the help option.*/
-        var helpOptionMessage: String = parent?.helpOptionMessage ?: "Show this message and exit"
+        /** The description of the help option, or `null` to use the default from the [localization]. */
+        var helpOptionMessage: String? = parent?.helpOptionMessage
 
-        /** The help formatter for this command*/
-        var helpFormatter: HelpFormatter = parent?.helpFormatter ?: CliktHelpFormatter()
+        /** The help formatter for this command, or null to use the default */
+        var helpFormatter: HelpFormatter? = parent?.helpFormatter
 
         /** An optional transformation function that is called to transform command line */
         var tokenTransformer: Context.(String) -> String = parent?.tokenTransformer ?: { it }
@@ -191,9 +191,11 @@ class Context(
                 block()
                 val interspersed = allowInterspersedArgs && !command.allowMultipleSubcommands &&
                         parent?.let { p -> p.ancestors().any { it.command.allowMultipleSubcommands } } != true
+                val formatter = helpFormatter ?: CliktHelpFormatter(localization)
+                val helpMessage = helpOptionMessage ?: localization.helpOptionMessage()
                 return Context(
                         parent, command, interspersed, autoEnvvarPrefix, printExtraMessages,
-                        helpOptionNames, helpOptionMessage, helpFormatter, tokenTransformer,
+                        helpOptionNames, helpMessage, formatter, tokenTransformer,
                         console, expandArgumentFiles, readEnvvarBeforeValueSource, valueSource,
                         correctionSuggestor, localization
                 )

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/exceptions.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/exceptions.kt
@@ -146,17 +146,7 @@ class NoSuchSubcommand(
         context: Context? = null
 ) : NoSuchParameter(context) {
     override fun formatMessage(): String {
-        val suggestion = when (possibilities.size) {
-            0 -> return localization.noSuchSubcommand(givenName)
-            1 -> localization.didYouMean(possibilities[0])
-            else -> possibilities.joinToString(
-                    separator = localization.listSeparator(),
-                    prefix = localization.possibleSubcommandsPrefix(),
-                    postfix = localization.possibleParameterPostfix()
-            )
-        }
-
-        return localization.noSuchSubcommand(givenName, suggestion)
+        return localization.noSuchSubcommand(givenName, possibilities)
     }
 }
 
@@ -168,17 +158,7 @@ class NoSuchOption(
         context: Context? = null
 ) : NoSuchParameter(context) {
     override fun formatMessage(): String {
-        val suggestion = when (possibilities.size) {
-            0 -> return localization.noSuchOption(givenName)
-            1 -> localization.didYouMean(possibilities[0])
-            else -> possibilities.joinToString(
-                    separator = localization.listSeparator(),
-                    prefix = localization.possibleOptionsPrefix(),
-                    postfix = localization.possibleParameterPostfix()
-            )
-        }
-
-        return localization.noSuchOption(givenName, suggestion)
+        return localization.noSuchOption(givenName, possibilities)
     }
 }
 
@@ -190,11 +170,7 @@ class IncorrectOptionValueCount(
         context: Context? = null
 ) : UsageError("", option, context) {
     override fun formatMessage(): String {
-        return when (val count = option!!.nvalues) {
-            0 -> localization.incorrectOptionValueCountZero(givenName)
-            1 -> localization.incorrectOptionValueCountOne(givenName)
-            else -> localization.incorrectOptionValueCountMany(givenName, count)
-        }
+        return  localization.incorrectOptionValueCount(givenName, option!!.nvalues)
     }
 }
 
@@ -217,8 +193,7 @@ class MutuallyExclusiveGroupException(
     }
 
     override fun formatMessage(): String {
-        val others = names.drop(1).joinToString(localization.mutexGroupExceptionNameSeparator())
-        return localization.mutexGroupException(names.first(), others)
+        return localization.mutexGroupException(names.first(), names.drop(1))
     }
 }
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatter.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/CliktHelpFormatter.kt
@@ -5,16 +5,11 @@ import com.github.ajalt.clikt.mpp.readEnvvar
 
 @Suppress("MemberVisibilityCanBePrivate")
 open class CliktHelpFormatter(
+        protected val localization: Localization = defaultLocalization,
         protected val indent: String = "  ",
         width: Int? = null,
         maxWidth: Int = 78,
         maxColWidth: Int? = null,
-        protected val usageTitle: String = "Usage:",
-        protected val optionsTitle: String = "Options:",
-        protected val argumentsTitle: String = "Arguments:",
-        protected val commandsTitle: String = "Commands:",
-        protected val optionsMetavar: String = "[OPTIONS]",
-        protected val commandMetavar: String = "COMMAND [ARGS]...",
         protected val colSpacing: Int = 2,
         protected val requiredOptionMarker: String? = null,
         protected val showDefaultValues: Boolean = false,
@@ -49,10 +44,10 @@ open class CliktHelpFormatter(
             parameters: List<HelpFormatter.ParameterHelp>,
             programName: String
     ) {
-        val prog = "${renderSectionTitle(usageTitle)} $programName"
+        val prog = "${renderSectionTitle(localization.usageTitle())} $programName"
         val usage = buildString {
             if (parameters.any { it is HelpFormatter.ParameterHelp.Option }) {
-                append(optionsMetavar)
+                append(localization.optionsMetavar())
             }
 
             parameters.filterIsInstance<HelpFormatter.ParameterHelp.Argument>().forEach {
@@ -64,7 +59,7 @@ open class CliktHelpFormatter(
             }
 
             if (parameters.any { it is HelpFormatter.ParameterHelp.Subcommand }) {
-                append(" ").append(commandMetavar)
+                append(" ").append(localization.commandMetavar())
             }
         }
 
@@ -94,7 +89,8 @@ open class CliktHelpFormatter(
                 .toList()
                 .sortedBy { it.first == null }
                 .forEach { (title, params) ->
-                    addOptionGroup(title?.let { "$it:" } ?: optionsTitle, groupsByName[title]?.help, params)
+                    addOptionGroup(title?.let { "$it:" }
+                            ?: localization.optionsTitle(), groupsByName[title]?.help, params)
                 }
     }
 
@@ -124,7 +120,7 @@ open class CliktHelpFormatter(
         }
         if (arguments.isNotEmpty() && arguments.any { it.col2.isNotEmpty() }) {
             append("\n")
-            section(argumentsTitle)
+            section(localization.argumentsTitle())
             appendDefinitionList(arguments)
         }
     }
@@ -135,7 +131,7 @@ open class CliktHelpFormatter(
         }
         if (commands.isNotEmpty()) {
             append("\n")
-            section(commandsTitle)
+            section(localization.commandsTitle())
             appendDefinitionList(commands)
         }
     }
@@ -168,7 +164,12 @@ open class CliktHelpFormatter(
     }
 
     protected open fun renderTag(tag: String, value: String): String {
-        return if (value.isBlank()) "($tag)" else "($tag: $value)"
+        val t = when(tag) {
+            HelpFormatter.Tags.DEFAULT -> localization.helpTagDefault()
+            HelpFormatter.Tags.REQUIRED -> localization.helpTagRequired()
+            else -> tag
+        }
+        return if (value.isBlank()) "($t)" else "($t: $value)"
     }
 
     protected open fun renderOptionName(name: String): String = name

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -177,6 +177,24 @@ interface Localization {
 
     /** Invalid path type */
     fun pathIsSymlink(pathType: String, path: String) = "$pathType \"$path\" is a symlink."
+
+    /** Metavar used for options with unspecified value type */
+    fun defaultMetavar() = "VALUE"
+
+    /** Metavar used for options that take [String] values */
+    fun stringMetavar() = "TEXT"
+
+    /** Metavar used for options that take [Float] or [Double] values */
+    fun floatMetavar() = "FLOAT"
+
+    /** Metavar used for options that take [Int] or [Long] values */
+    fun intMetavar() = "INT"
+
+    /** Metavar used for options that take `File` or `Path` values */
+    fun pathMetavar() = "PATH"
+
+    /** Metavar used for options that take `InputStream` or `OutputStream` values */
+    fun fileMetavar() = "FILE"
 }
 
 internal val defaultLocalization = object : Localization {}

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -33,46 +33,57 @@ interface Localization {
     fun missingArgument(paramName: String) = "Missing argument \"$paramName\""
 
     /** Message for [NoSuchSubcommand] */
-    fun noSuchSubcommand(name: String) = "no such subcommand: \"$name\""
-
-    /** Message for [NoSuchSubcommand] */
-    fun noSuchSubcommand(name: String, suggestion: String) = "no such subcommand: \"$name\". $suggestion"
+    fun noSuchSubcommand(name: String, possibilities: List<String>): String {
+        return "no such subcommand: \"$name\"" + when(possibilities.size) {
+            0 -> ""
+            1 -> ". Did you mean \"${possibilities[0]}\"?"
+            else ->  possibilities.joinToString(prefix = ". (Possible subcommands: ", postfix = ")")
+        }
+    }
 
     /** Message for [NoSuchOption] */
-    fun noSuchOption(name: String) = "no such option: \"$name\""
+    fun noSuchOption(name: String, possibilities: List<String>): String {
+        return "no such option: \"$name\"" + when(possibilities.size) {
+            0 -> ""
+            1 -> ". Did you mean \"${possibilities[0]}\"?"
+            else ->  possibilities.joinToString(prefix = ". (Possible options: ", postfix = ")")
+        }
+    }
 
-    /** Message for [NoSuchOption] */
-    fun noSuchOption(name: String, suggestion: String) = "no such option: \"$name\". $suggestion"
+    /**
+     * Message for [IncorrectOptionValueCount]
+     *
+     * @param count non-negative count of required values
+     */
+    fun incorrectOptionValueCount(name: String, count: Int): String {
+        return when (count) {
+            0 -> "option $name does not take a value"
+            1 -> "option $name requires a value"
+            else -> "option $name requires $count values"
+        }
+    }
 
-    /** A single suggestion for [noSuchOption] and [noSuchSubcommand]*/
-    fun didYouMean(possibility: String) = "Did you mean \"$possibility\"?"
+    /**
+     * Message for [IncorrectArgumentValueCount]
+     *
+     * @param count non-negative count of required values
+     */
+    fun incorrectArgumentValueCount(name: String, count: Int): String {
+        return when (count) {
+            0 -> "argument $name does not take a value"
+            1 -> "argument $name requires a value"
+            else -> "argument $name requires $count values"
+        }
+    }
 
-    /** Multiple suggestions for [noSuchOption] are joined with this prefix */
-    fun possibleOptionsPrefix() = "(Possible options: "
-
-    /** Multiple suggestions for [noSuchSubcommand] are joined with this prefix */
-    fun possibleSubcommandsPrefix() = "(Possible subcommands: "
-
-    /** Multiple suggestions for [noSuchOption] and [noSuchSubcommand] are join with this postfix */
-    fun possibleParameterPostfix() = ")"
-
-    /** Message for [IncorrectOptionValueCount] when the option does not take a value*/
-    fun incorrectOptionValueCountZero(name: String) = "$name option does not take a value"
-
-    /** Message for [IncorrectOptionValueCount] when the option requires one value */
-    fun incorrectOptionValueCountOne(name: String) = "$name option requires a value"
-
-    /** Message for [IncorrectOptionValueCount] when the option requires more than one value */
-    fun incorrectOptionValueCountMany(name: String, count: Int) = "$name option requires $count values"
-
-    /** Message for [IncorrectArgumentValueCount] */
-    fun incorrectArgumentValueCount(name: String, count: Int) = "argument $name takes $count values"
-
-    /** Message for [MutuallyExclusiveGroupException] */
-    fun mutexGroupException(name: String, others: String) = "option $name cannot be used with $others"
-
-    /** Separator used to join option names for [mutexGroupException]*/
-    fun mutexGroupExceptionNameSeparator() = " or "
+    /**
+     * Message for [MutuallyExclusiveGroupException]
+     *
+     * @param others non-empty list of other options in the group
+     */
+    fun mutexGroupException(name: String, others: List<String>): String {
+        return "option $name cannot be used with ${others.joinToString(" or ")}"
+    }
 
     /** Message for [FileNotFound] */
     fun fileNotFound(filename: String) = "$filename not found"
@@ -104,8 +115,14 @@ interface Localization {
     /** Required [MutuallyExclusiveOptions] was not provided */
     fun requiredMutexOption(options: String) = "Must provide one of $options"
 
-    /** [ChoiceGroup] value was invalid */
-    fun invalidGroupChoice(value: String, choices: String) = "invalid choice: $value. (choose from $choices)"
+    /**
+     * [ChoiceGroup] value was invalid
+     *
+     * @param choices non-empty list of possible choices
+     */
+    fun invalidGroupChoice(value: String, choices: List<String>): String {
+        return "invalid choice: $value. (choose from ${choices.joinToString()})"
+    }
 
     /** Invalid value for a parameter of type [Double] or [Float] */
     fun floatConversionError(value: String) = "$value is not a valid floating point value"
@@ -125,8 +142,14 @@ interface Localization {
     /** Invalid value falls outside range */
     fun rangeExceededBoth(value: String, min: String, max: String) = "$value is not in the valid range of $min to $max."
 
-    /** Invalid value for `choice` parameter */
-    fun invalidChoice(choice: String, choices: String) = "invalid choice: $choice. (choose from $choices)"
+    /**
+     * Invalid value for `choice` parameter
+     *
+     * @param choices non-empty list of possible choices
+     */
+    fun invalidChoice(choice: String, choices: List<String>): String {
+        return "invalid choice: $choice. (choose from ${choices.joinToString()})"
+    }
 
     /** The `pathType` parameter to [pathDoesNotExist] and other `path*` errors */
     fun pathTypeFile() = "File"
@@ -154,9 +177,6 @@ interface Localization {
 
     /** Invalid path type */
     fun pathIsSymlink(pathType: String, path: String) = "$pathType \"$path\" is a symlink."
-
-    /** String used to join multiple items into a list */
-    fun listSeparator() = ", "
 }
 
 internal val defaultLocalization = object : Localization {}

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -1,0 +1,162 @@
+package com.github.ajalt.clikt.output
+
+import com.github.ajalt.clikt.core.*
+import com.github.ajalt.clikt.parameters.groups.ChoiceGroup
+import com.github.ajalt.clikt.parameters.groups.MutuallyExclusiveOptions
+
+/**
+ * Strings to use for help output and error messages
+ */
+interface Localization {
+    /** [Abort] was thrown */
+    fun aborted() = "Aborted!"
+
+    /** Prefix for any [UsageError] */
+    fun usageError(message: String) = "Error: $message"
+
+    /** Message for [BadParameterValue] */
+    fun badParameter() = "Invalid value"
+
+    /** Message for [BadParameterValue] */
+    fun badParameterWithMessage(message: String) = "Invalid value: $message"
+
+    /** Message for [BadParameterValue] */
+    fun badParameterWithParam(paramName: String) = "Invalid value for \"$paramName\""
+
+    /** Message for [BadParameterValue] */
+    fun badParameterWithMessageAndParam(paramName: String, message: String) = "Invalid value for \"$paramName\": $message"
+
+    /** Message for [MissingOption] */
+    fun missingOption(paramName: String) = "Missing option \"$paramName\""
+
+    /** Message for [MissingArgument] */
+    fun missingArgument(paramName: String) = "Missing argument \"$paramName\""
+
+    /** Message for [NoSuchSubcommand] */
+    fun noSuchSubcommand(name: String) = "no such subcommand: \"$name\""
+
+    /** Message for [NoSuchSubcommand] */
+    fun noSuchSubcommand(name: String, suggestion: String) = "no such subcommand: \"$name\". $suggestion"
+
+    /** Message for [NoSuchOption] */
+    fun noSuchOption(name: String) = "no such option: \"$name\""
+
+    /** Message for [NoSuchOption] */
+    fun noSuchOption(name: String, suggestion: String) = "no such option: \"$name\". $suggestion"
+
+    /** A single suggestion for [noSuchOption] and [noSuchSubcommand]*/
+    fun didYouMean(possibility: String) = "Did you mean \"$possibility\"?"
+
+    /** Multiple suggestions for [noSuchOption] are joined with this prefix */
+    fun possibleOptionsPrefix() = "(Possible options: "
+
+    /** Multiple suggestions for [noSuchSubcommand] are joined with this prefix */
+    fun possibleSubcommandsPrefix() = "(Possible subcommands: "
+
+    /** Multiple suggestions for [noSuchOption] and [noSuchSubcommand] are join with this postfix */
+    fun possibleParameterPostfix() = ")"
+
+    /** Message for [IncorrectOptionValueCount] when the option does not take a value*/
+    fun incorrectOptionValueCountZero(name: String) = "$name option does not take a value"
+
+    /** Message for [IncorrectOptionValueCount] when the option requires one value */
+    fun incorrectOptionValueCountOne(name: String) = "$name option requires a value"
+
+    /** Message for [IncorrectOptionValueCount] when the option requires more than one value */
+    fun incorrectOptionValueCountMany(name: String, count: Int) = "$name option requires $count values"
+
+    /** Message for [IncorrectArgumentValueCount] */
+    fun incorrectArgumentValueCount(name: String, count: Int) = "argument $name takes $count values"
+
+    /** Message for [MutuallyExclusiveGroupException] */
+    fun mutexGroupException(name: String, others: String) = "option $name cannot be used with $others"
+
+    /** Separator used to join option names for [mutexGroupException]*/
+    fun mutexGroupExceptionNameSeparator() = " or "
+
+    /** Message for [FileNotFound] */
+    fun fileNotFound(filename: String) = "$filename not found"
+
+    /** Message for [InvalidFileFormat]*/
+    fun invalidFileFormat(filename: String, message: String) = "incorrect format in file $filename: $message"
+
+    /** Message for [InvalidFileFormat]*/
+    fun invalidFileFormat(filename: String, lineNumber: Int, message: String) = "incorrect format in file $filename line $lineNumber: $message"
+
+    /** Error in message for [InvalidFileFormat] */
+    fun unclosedQuote() = "unclosed quote"
+
+    /** Error in message for [InvalidFileFormat] */
+    fun fileEndsWithSlash() = "file ends with \\"
+
+    /** One extra argument is present */
+    fun extraArgumentOne(name: String) = "Got unexpected extra argument $name"
+
+    /** More than one extra argument is present */
+    fun extraArgumentMany(name: String, count: Int) = "Got unexpected extra arguments $name"
+
+    /** Error message when reading flag option from a file */
+    fun invalidFlagValueInFile(name: String) = "Invalid flag value in file for option $name"
+
+    /** Error message when reading switch option from environment variable */
+    fun switchOptionEnvvar() = "environment variables not supported for switch options"
+
+    /** Required [MutuallyExclusiveOptions] was not provided */
+    fun requiredMutexOption(options: String) = "Must provide one of $options"
+
+    /** [ChoiceGroup] value was invalid */
+    fun invalidGroupChoice(value: String, choices: String) = "invalid choice: $value. (choose from $choices)"
+
+    /** Invalid value for a parameter of type [Double] or [Float] */
+    fun floatConversionError(value: String) = "$value is not a valid floating point value"
+
+    /** Invalid value for a parameter of type [Int] or [Long] */
+    fun intConversionError(value: String) = "$value is not a valid integer"
+
+    /** Invalid value for a parameter of type [Boolean] */
+    fun boolConversionError(value: String) = "$value is not a valid boolean"
+
+    /** Invalid value falls outside range */
+    fun rangeExceededMax(value: String, limit: String) = "$value is larger than the maximum valid value of $limit."
+
+    /** Invalid value falls outside range */
+    fun rangeExceededMin(value: String, limit: String) = "$value is smaller than the minimum valid value of $limit."
+
+    /** Invalid value falls outside range */
+    fun rangeExceededBoth(value: String, min: String, max: String) = "$value is not in the valid range of $min to $max."
+
+    /** Invalid value for `choice` parameter */
+    fun invalidChoice(choice: String, choices: String) = "invalid choice: $choice. (choose from $choices)"
+
+    /** The `pathType` parameter to [pathDoesNotExist] and other `path*` errors */
+    fun pathTypeFile() = "File"
+
+    /** The `pathType` parameter to [pathDoesNotExist] and other `path*` errors */
+    fun pathTypeDirectory() = "Directory"
+
+    /** The `pathType` parameter to [pathDoesNotExist] and other `path*` errors */
+    fun pathTypeOther() = "Path"
+
+    /** Invalid path type */
+    fun pathDoesNotExist(pathType: String, path: String) = "$pathType \"$path\" does not exist."
+
+    /** Invalid path type */
+    fun pathIsFile(pathType: String, path: String) = "$pathType \"$path\" is a file."
+
+    /** Invalid path type */
+    fun pathIsDirectory(pathType: String, path: String) = "$pathType \"$path\" is a directory."
+
+    /** Invalid path type */
+    fun pathIsNotWritable(pathType: String, path: String) = "$pathType \"$path\" is not writable."
+
+    /** Invalid path type */
+    fun pathIsNotReadable(pathType: String, path: String) = "$pathType \"$path\" is not readable."
+
+    /** Invalid path type */
+    fun pathIsSymlink(pathType: String, path: String) = "$pathType \"$path\" is a symlink."
+
+    /** String used to join multiple items into a list */
+    fun listSeparator() = ", "
+}
+
+internal val defaultLocalization = object : Localization {}

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -195,6 +195,33 @@ interface Localization {
 
     /** Metavar used for options that take `InputStream` or `OutputStream` values */
     fun fileMetavar() = "FILE"
+
+    /** The title for the usage section of help output */
+    fun usageTitle(): String = "Usage:"
+
+    /** The title for the options section of help output */
+    fun optionsTitle(): String = "Options:"
+
+    /** The title for the arguments section of help output */
+    fun argumentsTitle(): String = "Arguments:"
+
+    /** The title for the subcommands section of help output */
+    fun commandsTitle(): String = "Commands:"
+
+    /** The that indicates where options may be present in the usage help output */
+    fun optionsMetavar(): String = "[OPTIONS]"
+
+    /** The that indicates where subcommands may be present in the usage help output */
+    fun commandMetavar(): String = "COMMAND [ARGS]..."
+
+    /** Text rendered for parameters tagged with [HelpFormatter.Tags.DEFAULT] */
+    fun helpTagDefault(): String = "default"
+
+    /** Text rendered for parameters tagged with [HelpFormatter.Tags.REQUIRED] */
+    fun helpTagRequired(): String = "required"
+
+    /** The default message for the `--help` option. This can be overridden with [Context.helpOptionMessage] */
+    fun helpOptionMessage(): String = "Show this message and exit"
 }
 
 internal val defaultLocalization = object : Localization {}

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -220,7 +220,7 @@ interface Localization {
     /** Text rendered for parameters tagged with [HelpFormatter.Tags.REQUIRED] */
     fun helpTagRequired(): String = "required"
 
-    /** The default message for the `--help` option. This can be overridden with [Context.helpOptionMessage] */
+    /** The default message for the `--help` option. */
     fun helpOptionMessage(): String = "Show this message and exit"
 }
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/arguments/Argument.kt
@@ -47,7 +47,7 @@ interface Argument {
     val completionCandidates: CompletionCandidates get() = CompletionCandidates.None
 
     /** Information about this argument for the help output. */
-    val parameterHelp: ParameterHelp.Argument?
+    fun parameterHelp(context: Context): ParameterHelp.Argument?
 
     /**
      * Called after this command's argv is parsed to transform and store the argument's value.
@@ -131,8 +131,7 @@ class ProcessedArgument<AllT, ValueT> internal constructor(
     override val completionCandidates: CompletionCandidates
         get() = completionCandidatesWithDefault.value
 
-    override val parameterHelp
-        get() = ParameterHelp.Argument(name, argumentHelp, required || nvalues > 1, nvalues < 0, helpTags)
+    override fun parameterHelp(context: Context) = ParameterHelp.Argument(name, argumentHelp, required || nvalues > 1, nvalues < 0, helpTags)
 
     override fun getValue(thisRef: CliktCommand, property: KProperty<*>): AllT = value
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/ChoiceGroup.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/ChoiceGroup.kt
@@ -3,7 +3,7 @@ package com.github.ajalt.clikt.parameters.groups
 import com.github.ajalt.clikt.core.BadParameterValue
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.core.MissingParameter
+import com.github.ajalt.clikt.core.MissingOption
 import com.github.ajalt.clikt.parameters.internal.NullableLateinit
 import com.github.ajalt.clikt.parameters.options.Option
 import com.github.ajalt.clikt.parameters.options.OptionDelegate
@@ -53,7 +53,7 @@ class ChoiceGroup<GroupT : OptionGroup, OutT> internal constructor(
 
         val group = groups[key]
                 ?: throw BadParameterValue(
-                        "invalid choice: $key. (choose from ${groups.keys.joinToString()})",
+                        context.localization.invalidGroupChoice(key, groups.keys.joinToString(context.localization.listSeparator())),
                         option,
                         context
                 )
@@ -99,7 +99,7 @@ fun <T : OptionGroup> RawOption.groupChoice(vararg choices: Pair<String, T>): Ch
 
 /**
  * If a [groupChoice] or [groupSwitch] option is not called on the command line, throw a
- * [MissingParameter] exception.
+ * [MissingOption] exception.
  *
  * ### Example:
  *
@@ -108,7 +108,7 @@ fun <T : OptionGroup> RawOption.groupChoice(vararg choices: Pair<String, T>): Ch
  * ```
  */
 fun <T : OptionGroup> ChoiceGroup<T, T?>.required(): ChoiceGroup<T, T> {
-    return ChoiceGroup(option, groups) { it ?: throw MissingParameter(option) }
+    return ChoiceGroup(option, groups) { it ?: throw MissingOption(option) }
 }
 
 /**

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/ChoiceGroup.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/ChoiceGroup.kt
@@ -51,12 +51,11 @@ class ChoiceGroup<GroupT : OptionGroup, OutT> internal constructor(
             return
         }
 
-        val group = groups[key]
-                ?: throw BadParameterValue(
-                        context.localization.invalidGroupChoice(key, groups.keys.joinToString(context.localization.listSeparator())),
-                        option,
-                        context
-                )
+        val group = groups[key] ?: throw BadParameterValue(
+                context.localization.invalidGroupChoice(key, groups.keys.toList()),
+                option,
+                context
+        )
         group.finalize(context, invocationsByOption.filterKeys { it in group.options })
         chosenGroup = group
         value = transform(group)

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/ParameterGroup.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/groups/ParameterGroup.kt
@@ -24,12 +24,11 @@ interface ParameterGroup {
      */
     val groupHelp: String?
 
-    val parameterHelp: HelpFormatter.ParameterHelp.Group?
-        get() {
-            val n = groupName
-            val h = groupHelp
-            return if (n == null || h == null) null else HelpFormatter.ParameterHelp.Group(n, h)
-        }
+    fun parameterHelp(context: Context): HelpFormatter.ParameterHelp.Group? {
+        val n = groupName
+        val h = groupHelp
+        return if (n == null || h == null) null else HelpFormatter.ParameterHelp.Group(n, h)
+    }
 
     /**
      * Called after this command's argv is parsed and all options are validated to validate the group constraints.

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/EagerOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/EagerOption.kt
@@ -33,7 +33,7 @@ class EagerOption(
 
     override val secondaryNames: Set<String> get() = emptySet()
     override val parser: OptionParser = FlagOptionParser
-    override val metavar: String? get() = null
+    override fun metavar(context: Context): String? = null
     override val valueSourceKey: String? get() = null
     override fun postValidate(context: Context) {}
     override fun finalize(context: Context, invocations: List<OptionParser.Invocation>) {

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -35,7 +35,7 @@ class FlagOption<T> internal constructor(
 ) : OptionDelegate<T> {
     override var parameterGroup: ParameterGroup? = null
     override var groupName: String? = null
-    override val metavar: String? = null
+    override fun metavar(context: Context): String? = null
     override val nvalues: Int get() = 0
     override val parser = FlagOptionParser
     override var value: T by NullableLateinit("Cannot read from option delegate before parsing command line")

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -55,7 +55,8 @@ class FlagOption<T> internal constructor(
             is FinalValue.Parsed -> transformAll(transformContext, invocations.map { it.name })
             is FinalValue.Sourced -> {
                 if (v.values.size != 1 || v.values[0].values.size != 1) {
-                    throw UsageError("Invalid flag value in file for option ${longestName()}", this)
+                    val message = context.localization.invalidFlagValueInFile(longestName() ?: "")
+                    throw UsageError(message, this)
                 }
                 transformEnvvar(transformContext, v.values[0].values[0])
             }
@@ -155,7 +156,7 @@ fun RawOption.flag(
                 when (it.toLowerCase()) {
                     "true", "t", "1", "yes", "y", "on" -> true
                     "false", "f", "0", "no", "n", "off" -> false
-                    else -> throw BadParameterValue("$it is not a valid boolean", this)
+                    else -> throw BadParameterValue(context.localization.boolConversionError(it), this)
                 }
             },
             transformAll = {
@@ -236,7 +237,7 @@ fun RawOption.counted(): FlagOption<Int> {
             helpTags = helpTags,
             valueSourceKey = valueSourceKey,
             envvar = envvar,
-            transformEnvvar = { valueToInt(it) },
+            transformEnvvar = { valueToInt(context, it) },
             transformAll = { it.size },
             validator = {}
     )
@@ -262,7 +263,7 @@ fun <T : Any> RawOption.switch(choices: Map<String, T>): FlagOption<T?> {
             valueSourceKey = null,
             envvar = null,
             transformEnvvar = {
-                throw UsageError("environment variables not supported for switch options", this)
+                throw UsageError(context.localization.switchOptionEnvvar(), this)
             },
             transformAll = { names -> names.map { choices.getValue(it) }.lastOrNull() },
             validator = {}

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Option.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Option.kt
@@ -17,7 +17,7 @@ import kotlin.reflect.KProperty
  */
 interface Option {
     /** A name representing the values for this option that can be displayed to the user. */
-    val metavar: String?
+    fun metavar(context: Context): String?
 
     /** The description of this option, usually a single line. */
     val optionHelp: String
@@ -47,14 +47,13 @@ interface Option {
     val valueSourceKey: String?
 
     /** Information about this option for the help output. */
-    val parameterHelp: HelpFormatter.ParameterHelp.Option?
-        get() = when {
-            hidden -> null
-            else -> HelpFormatter.ParameterHelp.Option(names, secondaryNames, metavar, optionHelp, nvalues, helpTags,
-                    groupName = (this as? StaticallyGroupedOption)?.groupName
-                            ?: (this as? GroupableOption)?.parameterGroup?.groupName
-            )
-        }
+    fun parameterHelp(context: Context): HelpFormatter.ParameterHelp.Option? = when {
+        hidden -> null
+        else -> HelpFormatter.ParameterHelp.Option(names, secondaryNames, metavar(context), optionHelp, nvalues, helpTags,
+                groupName = (this as? StaticallyGroupedOption)?.groupName
+                        ?: (this as? GroupableOption)?.parameterGroup?.groupName
+        )
+    }
 
     /**
      * Called after this command's argv is parsed to transform and store the option's value.

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/OptionWithValues.kt
@@ -97,7 +97,7 @@ typealias OptionValidator<AllT> = OptionTransformContext.(AllT) -> Unit
 // default("").int()
 class OptionWithValues<AllT, EachT, ValueT> internal constructor(
         names: Set<String>,
-        val metavarWithDefault: ValueWithDefault<String?>,
+        val metavarWithDefault: ValueWithDefault<Context.() -> String?>,
         override val nvalues: Int,
         override val optionHelp: String,
         override val hidden: Boolean,
@@ -114,7 +114,7 @@ class OptionWithValues<AllT, EachT, ValueT> internal constructor(
 ) : OptionDelegate<AllT>, GroupableOption {
     override var parameterGroup: ParameterGroup? = null
     override var groupName: String? = null
-    override val metavar: String? get() = metavarWithDefault.value
+    override fun metavar(context: Context): String? = metavarWithDefault.value.invoke(context)
     override var value: AllT by NullableLateinit("Cannot read from option delegate before parsing command line")
         private set
     override val secondaryNames: Set<String> get() = emptySet()
@@ -169,7 +169,7 @@ class OptionWithValues<AllT, EachT, ValueT> internal constructor(
             transformAll: CallsTransformer<EachT, AllT>,
             validator: OptionValidator<AllT>,
             names: Set<String> = this.names,
-            metavarWithDefault: ValueWithDefault<String?> = this.metavarWithDefault,
+            metavarWithDefault: ValueWithDefault<Context.() -> String?> = this.metavarWithDefault,
             nvalues: Int = this.nvalues,
             help: String = this.optionHelp,
             hidden: Boolean = this.hidden,
@@ -203,7 +203,7 @@ class OptionWithValues<AllT, EachT, ValueT> internal constructor(
     fun copy(
             validator: OptionValidator<AllT> = this.transformValidator,
             names: Set<String> = this.names,
-            metavarWithDefault: ValueWithDefault<String?> = this.metavarWithDefault,
+            metavarWithDefault: ValueWithDefault<Context.() -> String?> = this.metavarWithDefault,
             nvalues: Int = this.nvalues,
             help: String = this.optionHelp,
             hidden: Boolean = this.hidden,
@@ -275,7 +275,7 @@ fun ParameterHolder.option(
         valueSourceKey: String? = null
 ): RawOption = OptionWithValues(
         names = names.toSet(),
-        metavarWithDefault = ValueWithDefault(metavar, "TEXT"),
+        metavarWithDefault = ValueWithDefault(metavar?.let { { it } }, { localization.stringMetavar() }),
         nvalues = 1,
         optionHelp = help,
         hidden = hidden,

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/TransformAll.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/TransformAll.kt
@@ -4,7 +4,7 @@
 package com.github.ajalt.clikt.parameters.options
 
 import com.github.ajalt.clikt.core.Abort
-import com.github.ajalt.clikt.core.MissingParameter
+import com.github.ajalt.clikt.core.MissingOption
 import com.github.ajalt.clikt.output.HelpFormatter
 import com.github.ajalt.clikt.output.TermUi
 import kotlin.jvm.JvmMultifileClass
@@ -92,7 +92,7 @@ inline fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.defaultLazy(
 }
 
 /**
- * If the option is not called on the command line (and is not set in an envvar), throw a [MissingParameter].
+ * If the option is not called on the command line (and is not set in an envvar), throw a [MissingOption].
  *
  * This must be applied after all other transforms.
  *
@@ -103,7 +103,7 @@ inline fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.defaultLazy(
  * ```
  */
 fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.required(): OptionWithValues<EachT, EachT, ValueT> {
-    return transformAll(showAsRequired = true) { it.lastOrNull() ?: throw MissingParameter(option) }
+    return transformAll(showAsRequired = true) { it.lastOrNull() ?: throw MissingOption(option) }
 }
 
 /**
@@ -118,7 +118,7 @@ fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.required(): OptionWithVa
  * ```
  *
  * @param default The value to use if the option is not supplied. Defaults to an empty list.
- * @param required If true, [default] is ignored and [MissingParameter] will be thrown if no
+ * @param required If true, [default] is ignored and [MissingOption] will be thrown if no
  *   instances of the option are present on the command line.
  */
 fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.multiple(
@@ -127,7 +127,7 @@ fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.multiple(
 ): OptionWithValues<List<EachT>, EachT, ValueT> {
     return transformAll(showAsRequired = required) {
         when {
-            it.isEmpty() && required -> throw MissingParameter(option)
+            it.isEmpty() && required -> throw MissingOption(option)
             it.isEmpty() && !required -> default
             else -> it
         }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/choice.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/choice.kt
@@ -14,7 +14,7 @@ private fun mvar(choices: Iterable<String>): String {
 }
 
 private fun errorMessage(context: Context, choice: String, choices: Map<String, *>): String {
-    return context.localization.invalidChoice(choice, choices.keys.joinToString(context.localization.listSeparator()))
+    return context.localization.invalidChoice(choice, choices.keys.toList())
 }
 
 // arguments

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/choice.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/choice.kt
@@ -1,6 +1,7 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.completion.CompletionCandidates.Fixed
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.ProcessedArgument
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
@@ -12,8 +13,8 @@ private fun mvar(choices: Iterable<String>): String {
     return choices.joinToString("|", prefix = "[", postfix = "]")
 }
 
-private fun errorMessage(choice: String, choices: Map<String, *>): String {
-    return "invalid choice: $choice. (choose from ${choices.keys.joinToString(", ")})"
+private fun errorMessage(context: Context, choice: String, choices: Map<String, *>): String {
+    return context.localization.invalidChoice(choice, choices.keys.joinToString(context.localization.listSeparator()))
 }
 
 // arguments
@@ -33,7 +34,7 @@ fun <T : Any> RawArgument.choice(choices: Map<String, T>, ignoreCase: Boolean = 
     require(choices.isNotEmpty()) { "Must specify at least one choice" }
     val c = if (ignoreCase) choices.mapKeys { it.key.toLowerCase() } else choices
     return convert(completionCandidates = Fixed(choices.keys)) {
-        c[if (ignoreCase) it.toLowerCase() else it] ?: fail(errorMessage(it, choices))
+        c[if (ignoreCase) it.toLowerCase() else it] ?: fail(errorMessage(context, it, choices))
     }
 }
 
@@ -113,7 +114,7 @@ fun <T : Any> RawOption.choice(
     require(choices.isNotEmpty()) { "Must specify at least one choice" }
     val c = if (ignoreCase) choices.mapKeys { it.key.toLowerCase() } else choices
     return convert(metavar, completionCandidates = Fixed(choices.keys)) {
-        c[if (ignoreCase) it.toLowerCase() else it] ?: fail(errorMessage(it, choices))
+        c[if (ignoreCase) it.toLowerCase() else it] ?: fail(errorMessage(context, it, choices))
     }
 }
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
@@ -15,4 +15,4 @@ private fun valueToDouble(context: Context, it: String): Double {
 fun RawArgument.double() = convert { valueToDouble( context, it) }
 
 /** Convert the option values to a `Double` */
-fun RawOption.double() = convert("FLOAT") { valueToDouble(context,  it) }
+fun RawOption.double() = convert({ localization.floatMetavar() }) { valueToDouble(context, it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/double.kt
@@ -1,17 +1,18 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
 
-private fun valueToDouble(it: String): Double {
-    return it.toDoubleOrNull() ?: throw BadParameterValue("$it is not a valid floating point value")
+private fun valueToDouble(context: Context, it: String): Double {
+    return it.toDoubleOrNull() ?: throw BadParameterValue(context.localization.floatConversionError(it))
 }
 
 /** Convert the argument values to a `Double` */
-fun RawArgument.double() = convert { valueToDouble(it) }
+fun RawArgument.double() = convert { valueToDouble( context, it) }
 
 /** Convert the option values to a `Double` */
-fun RawOption.double() = convert("FLOAT") { valueToDouble(it) }
+fun RawOption.double() = convert("FLOAT") { valueToDouble(context,  it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
@@ -1,17 +1,18 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
 
-private fun valueToFloat(it: String): Float {
-    return it.toFloatOrNull() ?: throw BadParameterValue("$it is not a valid floating point value")
+private fun valueToFloat(context: Context, it: String): Float {
+    return it.toFloatOrNull() ?: throw BadParameterValue(context.localization.floatConversionError(it))
 }
 
 /** Convert the argument values to a `Float` */
-fun RawArgument.float() = convert { valueToFloat(it) }
+fun RawArgument.float() = convert { valueToFloat(context, it) }
 
 /** Convert the option values to a `Float` */
-fun RawOption.float() = convert("FLOAT") { valueToFloat(it) }
+fun RawOption.float() = convert("FLOAT") { valueToFloat(context, it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/float.kt
@@ -15,4 +15,4 @@ private fun valueToFloat(context: Context, it: String): Float {
 fun RawArgument.float() = convert { valueToFloat(context, it) }
 
 /** Convert the option values to a `Float` */
-fun RawOption.float() = convert("FLOAT") { valueToFloat(context, it) }
+fun RawOption.float() = convert({ localization.floatMetavar() }) { valueToFloat(context, it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
@@ -15,4 +15,4 @@ internal fun valueToInt(context: Context, it: String): Int {
 fun RawArgument.int() = convert { valueToInt(context, it) }
 
 /** Convert the option values to an `Int` */
-fun RawOption.int() = convert("INT") { valueToInt(context, it) }
+fun RawOption.int() = convert({ localization.intMetavar() }) { valueToInt(context, it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/int.kt
@@ -1,17 +1,18 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
 
-internal fun valueToInt(it: String): Int {
-    return it.toIntOrNull() ?: throw BadParameterValue("$it is not a valid integer")
+internal fun valueToInt(context: Context, it: String): Int {
+    return it.toIntOrNull() ?: throw BadParameterValue(context.localization.intConversionError(it))
 }
 
 /** Convert the argument values to an `Int` */
-fun RawArgument.int() = convert { valueToInt(it) }
+fun RawArgument.int() = convert { valueToInt(context, it) }
 
 /** Convert the option values to an `Int` */
-fun RawOption.int() = convert("INT") { valueToInt(it) }
+fun RawOption.int() = convert("INT") { valueToInt(context, it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
@@ -1,17 +1,18 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
 import com.github.ajalt.clikt.parameters.options.RawOption
 import com.github.ajalt.clikt.parameters.options.convert
 
-internal fun valueToLong(it: String): Long {
-    return it.toLongOrNull() ?: throw BadParameterValue("$it is not a valid integer")
+internal fun valueToLong(context: Context, it: String): Long {
+    return it.toLongOrNull() ?: throw BadParameterValue(context.localization.intConversionError(it))
 }
 
 /** Convert the argument values to a `Long` */
-fun RawArgument.long() = convert { valueToLong(it) }
+fun RawArgument.long() = convert { valueToLong(context, it) }
 
 /** Convert the option values to a `Long` */
-fun RawOption.long() = convert("INT") { valueToLong(it) }
+fun RawOption.long() = convert("INT") { valueToLong(context, it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/long.kt
@@ -15,4 +15,4 @@ internal fun valueToLong(context: Context, it: String): Long {
 fun RawArgument.long() = convert { valueToLong(context, it) }
 
 /** Convert the option values to a `Long` */
-fun RawOption.long() = convert("INT") { valueToLong(context, it) }
+fun RawOption.long() = convert({ localization.intMetavar() }) { valueToLong(context, it) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/sources/ValueSource.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/sources/ValueSource.kt
@@ -73,7 +73,6 @@ interface ValueSource {
                 is FlagOption<*> -> option.envvar
                 else -> null
             }
-            println("$env, ${inferEnvvar(option.names, env, context.autoEnvvarPrefix)}")
             inferEnvvar(option.names, env, context.autoEnvvarPrefix) ?: ""
         }
     }

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
@@ -135,7 +135,7 @@ class CliktCommandTest {
         }.helpMessage() shouldBe """
             |Usage: parent [OPTIONS] ARG
             |
-            |Error: Missing argument "ARG".
+            |Error: Missing argument "ARG"
             """.trimMargin()
     }
 
@@ -261,6 +261,6 @@ class CliktCommandTest {
         c.args shouldBe listOf("-g", "-i")
         shouldThrow<NoSuchOption> {
             C(false).parse("-fgi")
-        }.message shouldBe "no such option: \"-g\"."
+        }.message shouldBe "no such option: \"-g\""
     }
 }

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
@@ -135,7 +135,7 @@ class ArgumentTest {
             val x by argument().pair()
         }
         shouldThrow<IncorrectArgumentValueCount> { C().parse("foo") }
-                .message shouldBe "argument X takes 2 values"
+                .message shouldBe "argument X requires 2 values"
         shouldThrow<UsageError> { C().parse("foo bar baz") }
                 .message shouldBe "Got unexpected extra argument (baz)"
         shouldThrow<UsageError> { C().parse("foo bar baz qux") }
@@ -150,7 +150,7 @@ class ArgumentTest {
         }
 
         shouldThrow<IncorrectArgumentValueCount> { C().parse("foo bar") }
-                .message shouldBe "argument X takes 3 values"
+                .message shouldBe "argument X requires 3 values"
         shouldThrow<UsageError> { C().parse("foo bar baz qux") }
                 .message shouldBe "Got unexpected extra argument (qux)"
 

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
@@ -27,8 +27,8 @@ class ArgumentTest {
             val foo by argument()
         }
 
-        shouldThrow<MissingParameter> { C().parse("") }
-                .message shouldBe "Missing argument \"FOO\"."
+        shouldThrow<MissingArgument> { C().parse("") }
+                .message shouldBe "Missing argument \"FOO\""
     }
 
     @Test
@@ -94,8 +94,8 @@ class ArgumentTest {
 
         C().parse("1 2")
 
-        shouldThrow<MissingParameter> { C().parse("") }
-                .message shouldBe "Missing argument \"X\"."
+        shouldThrow<MissingArgument> { C().parse("") }
+                .message shouldBe "Missing argument \"X\""
     }
 
     @Test
@@ -214,7 +214,7 @@ class ArgumentTest {
             val x by argument().multiple(required = true)
         }
 
-        shouldThrow<MissingParameter> { C().parse("") }
+        shouldThrow<MissingArgument> { C().parse("") }
     }
 
     @Test
@@ -242,7 +242,7 @@ class ArgumentTest {
             val foo by argument().multiple()
             val bar by argument()
         }
-        shouldThrow<MissingParameter> {
+        shouldThrow<MissingArgument> {
             C().parse("")
         }.message!! should contain("BAR")
     }
@@ -274,8 +274,8 @@ class ArgumentTest {
             val bar by argument().multiple()
         }
 
-        val ex = shouldThrow<MissingParameter> { C().parse("") }
-        ex.message!! should contain("Missing argument \"FOO\".")
+        val ex = shouldThrow<MissingArgument> { C().parse("") }
+        ex.message!! should contain("Missing argument \"FOO\"")
     }
 
     @Test
@@ -310,7 +310,7 @@ class ArgumentTest {
         C().parse("foo")
         called shouldBe true
 
-        shouldThrow<MissingParameter> { C().parse("") }
+        shouldThrow<MissingArgument> { C().parse("") }
     }
 
     @Test

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
@@ -493,11 +493,11 @@ class OptionTest {
             override fun run_() {
                 registeredOptions().forEach {
                     assertTrue(it is EagerOption || // skip help option
-                            "--x" in it.names && it.metavar == "TEXT" ||
-                            "--y" in it.names && it.metavar == "FOO" ||
-                            "--z" in it.names && it.metavar == "FOO" ||
-                            "--w" in it.names && it.metavar == "BAR" ||
-                            "--u" in it.names && it.metavar == null,
+                            "--x" in it.names && it.metavar(currentContext) == "TEXT" ||
+                            "--y" in it.names && it.metavar(currentContext) == "FOO" ||
+                            "--z" in it.names && it.metavar(currentContext) == "FOO" ||
+                            "--w" in it.names && it.metavar(currentContext) == "BAR" ||
+                            "--u" in it.names && it.metavar(currentContext) == null,
                             message = "bad option $it"
                     )
                 }

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
@@ -187,7 +187,7 @@ class OptionTest {
             val y by option("-y", "--yy").pair()
         }
         shouldThrow<IncorrectOptionValueCount> { C().parse("-x") }.message shouldBe
-                "-x option requires 2 values"
+                "option -x requires 2 values"
         shouldThrow<UsageError> { C().parse("--yy foo bar baz") }.message shouldBe
                 "Got unexpected extra argument (baz)"
     }

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
@@ -25,7 +25,7 @@ class OptionTest {
     @Test
     @JsName("no_such_option")
     fun `no such option`() = forAll(
-            row("--qux", "no such option: \"--qux\"."),
+            row("--qux", "no such option: \"--qux\""),
             row("--fo", "no such option: \"--fo\". Did you mean \"--foo\"?"),
             row("--fop", "no such option: \"--fop\". Did you mean \"--foo\"?"),
             row("--car", "no such option: \"--car\". Did you mean \"--bar\"?"),
@@ -187,7 +187,7 @@ class OptionTest {
             val y by option("-y", "--yy").pair()
         }
         shouldThrow<IncorrectOptionValueCount> { C().parse("-x") }.message shouldBe
-                "-x option requires 2 arguments"
+                "-x option requires 2 values"
         shouldThrow<UsageError> { C().parse("--yy foo bar baz") }.message shouldBe
                 "Got unexpected extra argument (baz)"
     }
@@ -394,9 +394,9 @@ class OptionTest {
 
         C().parse("--x=foo")
 
-        shouldThrow<MissingParameter> {
+        shouldThrow<MissingOption> {
             C().parse("")
-        }.message shouldBe "Missing option \"--x\"."
+        }.message shouldBe "Missing option \"--x\""
     }
 
     @Test
@@ -477,8 +477,8 @@ class OptionTest {
         C(true).apply { parse("--x 1"); x shouldBe listOf("1") }
         C(true).apply { parse("--x 2 --x 3"); x shouldBe listOf("2", "3") }
 
-        shouldThrow<MissingParameter> { C(false).parse("") }
-                .message shouldBe "Missing option \"--x\"."
+        shouldThrow<MissingOption> { C(false).parse("") }
+                .message shouldBe "Missing option \"--x\""
     }
 
     @Test
@@ -575,7 +575,7 @@ class OptionTest {
         called shouldBe true
 
         called = false
-        shouldThrow<MissingParameter> { C().parse("") }
+        shouldThrow<MissingOption> { C().parse("") }
     }
 
     @Test

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/SubcommandTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/SubcommandTest.kt
@@ -255,13 +255,13 @@ class SubcommandTest {
         }.helpMessage() shouldBe """
             |Usage: parent child grandchild [OPTIONS] ARG
             |
-            |Error: Missing argument "ARG".
+            |Error: Missing argument "ARG"
             """.trimMargin()
     }
 
     @Test
     fun noSuchSubcommand() = forAll(
-            row("qux", "no such subcommand: \"qux\"."),
+            row("qux", "no such subcommand: \"qux\""),
             row("fo", "no such subcommand: \"fo\". Did you mean \"foo\"?"),
             row("fop", "no such subcommand: \"fop\". Did you mean \"foo\"?"),
             row("bart", "no such subcommand: \"bart\". Did you mean \"bar\"?"),

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
@@ -2,10 +2,7 @@
 
 package com.github.ajalt.clikt.parameters.groups
 
-import com.github.ajalt.clikt.core.BadParameterValue
-import com.github.ajalt.clikt.core.MissingParameter
-import com.github.ajalt.clikt.core.MutuallyExclusiveGroupException
-import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.*
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.testing.TestCommand
@@ -65,9 +62,9 @@ class OptionGroupsTest {
 
         C().parse("--x=foo")
 
-        shouldThrow<MissingParameter> {
+        shouldThrow<MissingOption> {
             C().parse("")
-        }.message shouldBe "Missing option \"--x\"."
+        }.message shouldBe "Missing option \"--x\""
     }
 
     @Test
@@ -234,7 +231,7 @@ class OptionGroupsTest {
         }
 
         shouldThrow<UsageError> { C().parse("--y=2") }
-                .message shouldBe "Missing option \"--x\"."
+                .message shouldBe "Missing option \"--x\""
     }
 
     @Test
@@ -356,7 +353,7 @@ class OptionGroupsTest {
     fun `cooccurring option group validation`() = forAll(
             row("", null, true, null),
             row("--x=1 --y=1", 1, true, null),
-            row("--x=2", null, false, "Missing option \"--y\"."),
+            row("--x=2", null, false, "Missing option \"--y\""),
             row("--x=2 --y=1", null, false, "Invalid value for \"--x\": fail")
     ) { argv, ex, ec, em ->
         if (skipDueToKT33294) return@forAll

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/file.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/file.kt
@@ -82,7 +82,7 @@ fun RawOption.file(
         mustBeReadable: Boolean = false,
         canBeSymlink: Boolean = true
 ): NullableOption<File, File> {
-    return convert("PATH", completionCandidates = CompletionCandidates.Path) { str ->
+    return convert({ localization.pathMetavar() }, CompletionCandidates.Path) { str ->
         convertToFile(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, context) { fail(it) }
     }
 }

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/file.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/file.kt
@@ -1,6 +1,7 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.completion.CompletionCandidates
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.ProcessedArgument
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
@@ -10,10 +11,10 @@ import com.github.ajalt.clikt.parameters.options.convert
 import java.io.File
 import java.nio.file.Files
 
-private fun pathType(fileOkay: Boolean, folderOkay: Boolean): String = when {
-    fileOkay && !folderOkay -> "File"
-    !fileOkay && folderOkay -> "Directory"
-    else -> "Path"
+private fun pathType(context: Context, fileOkay: Boolean, folderOkay: Boolean): String = when {
+    fileOkay && !folderOkay -> context.localization.pathTypeFile()
+    !fileOkay && folderOkay -> context.localization.pathTypeDirectory()
+    else -> context.localization.pathTypeOther()
 }
 
 private fun convertToFile(
@@ -24,16 +25,19 @@ private fun convertToFile(
         mustBeWritable: Boolean,
         mustBeReadable: Boolean,
         canBeSymlink: Boolean,
+        context: Context,
         fail: (String) -> Unit
 ): File {
-    val name = pathType(canBeFile, canBeDir)
-    return File(path).also {
-        if (mustExist && !it.exists()) fail("$name \"$it\" does not exist.")
-        if (!canBeFile && it.isFile) fail("$name \"$it\" is a file.")
-        if (!canBeDir && it.isDirectory) fail("$name \"$it\" is a directory.")
-        if (mustBeWritable && !it.canWrite()) fail("$name \"$it\" is not writable.")
-        if (mustBeReadable && !it.canRead()) fail("$name \"$it\" is not readable.")
-        if (!canBeSymlink && Files.isSymbolicLink(it.toPath())) fail("$name \"$it\" is a symlink.")
+    val name = pathType(context, canBeFile, canBeDir)
+    return with(context.localization) {
+        File(path).also {
+            if (mustExist && !it.exists()) fail(pathDoesNotExist(name, it.toString()))
+            if (!canBeFile && it.isFile) fail(pathIsFile(name, it.toString()))
+            if (!canBeDir && it.isDirectory) fail(pathIsDirectory(name, it.toString()))
+            if (mustBeWritable && !it.canWrite()) fail(pathIsNotWritable(name, it.toString()))
+            if (mustBeReadable && !it.canRead()) fail(pathIsNotReadable(name, it.toString()))
+            if (!canBeSymlink && Files.isSymbolicLink(it.toPath())) fail(pathIsSymlink(name, it.toString()))
+        }
     }
 }
 
@@ -56,7 +60,7 @@ fun RawArgument.file(
         canBeSymlink: Boolean = true
 ): ProcessedArgument<File, File> {
     return convert(completionCandidates = CompletionCandidates.Path) { str ->
-        convertToFile(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink) { fail(it) }
+        convertToFile(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, context) { fail(it) }
     }
 }
 
@@ -78,8 +82,7 @@ fun RawOption.file(
         mustBeReadable: Boolean = false,
         canBeSymlink: Boolean = true
 ): NullableOption<File, File> {
-    val name = pathType(canBeFile, canBeDir)
-    return convert(name.toUpperCase(), completionCandidates = CompletionCandidates.Path) { str ->
-        convertToFile(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink) { fail(it) }
+    return convert("PATH", completionCandidates = CompletionCandidates.Path) { str ->
+        convertToFile(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, context) { fail(it) }
     }
 }

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/inputStream.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/inputStream.kt
@@ -1,6 +1,7 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.completion.CompletionCandidates
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.*
 import com.github.ajalt.clikt.parameters.options.*
 import java.io.IOException
@@ -9,7 +10,7 @@ import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Files
 
-private fun convertToInputStream(s: String, fileSystem: FileSystem, fail: (String) -> Unit): InputStream {
+private fun convertToInputStream(s: String, fileSystem: FileSystem, context: Context, fail: (String) -> Unit): InputStream {
     return if (s == "-") {
         UnclosableInputStream(System.`in`)
     } else {
@@ -22,6 +23,7 @@ private fun convertToInputStream(s: String, fileSystem: FileSystem, fail: (Strin
                 mustBeReadable = true,
                 canBeSymlink = true,
                 fileSystem = fileSystem,
+                context = context,
                 fail = fail
         )
         Files.newInputStream(path)
@@ -44,7 +46,7 @@ fun RawOption.inputStream(
         fileSystem: FileSystem = FileSystems.getDefault()
 ): NullableOption<InputStream, InputStream> {
     return convert("FILE", completionCandidates = CompletionCandidates.Path) { s ->
-        convertToInputStream(s, fileSystem) { fail(it) }
+        convertToInputStream(s, fileSystem, context) { fail(it) }
     }
 }
 
@@ -72,7 +74,7 @@ fun RawArgument.inputStream(
         fileSystem: FileSystem = FileSystems.getDefault()
 ): ProcessedArgument<InputStream, InputStream> {
     return convert(completionCandidates = CompletionCandidates.Path) { s ->
-        convertToInputStream(s, fileSystem) { fail(it) }
+        convertToInputStream(s, fileSystem, context) { fail(it) }
     }
 }
 

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/inputStream.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/inputStream.kt
@@ -45,7 +45,7 @@ private fun convertToInputStream(s: String, fileSystem: FileSystem, context: Con
 fun RawOption.inputStream(
         fileSystem: FileSystem = FileSystems.getDefault()
 ): NullableOption<InputStream, InputStream> {
-    return convert("FILE", completionCandidates = CompletionCandidates.Path) { s ->
+    return convert({ localization.fileMetavar() }, CompletionCandidates.Path) { s ->
         convertToInputStream(s, fileSystem, context) { fail(it) }
     }
 }

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
@@ -59,7 +59,7 @@ fun RawOption.outputStream(
         truncateExisting: Boolean = false,
         fileSystem: FileSystem = FileSystems.getDefault()
 ): NullableOption<OutputStream, OutputStream> {
-    return convert("FILE", completionCandidates = CompletionCandidates.Path) { s ->
+    return convert({ localization.fileMetavar() }, CompletionCandidates.Path) { s ->
         convertToOutputStream(s, createIfNotExist, truncateExisting, fileSystem, context) { fail(it) }
     }
 }

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/outputStream.kt
@@ -1,6 +1,7 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.completion.CompletionCandidates
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.*
 import com.github.ajalt.clikt.parameters.options.*
 import java.io.IOException
@@ -15,6 +16,7 @@ private fun convertToOutputStream(
         createIfNotExist: Boolean,
         truncateExisting: Boolean,
         fileSystem: FileSystem,
+        context: Context,
         fail: (String) -> Unit
 ): OutputStream {
     return if (s == "-") {
@@ -28,7 +30,8 @@ private fun convertToOutputStream(
                 mustBeWritable = !createIfNotExist,
                 mustBeReadable = false,
                 canBeSymlink = true,
-                fileSystem = fileSystem
+                fileSystem = fileSystem,
+                context = context
         ) { fail(it) }
         val openType = if (truncateExisting) TRUNCATE_EXISTING else APPEND
         val options = arrayOf(WRITE, CREATE, openType)
@@ -57,7 +60,7 @@ fun RawOption.outputStream(
         fileSystem: FileSystem = FileSystems.getDefault()
 ): NullableOption<OutputStream, OutputStream> {
     return convert("FILE", completionCandidates = CompletionCandidates.Path) { s ->
-        convertToOutputStream(s, createIfNotExist, truncateExisting, fileSystem) { fail(it) }
+        convertToOutputStream(s, createIfNotExist, truncateExisting, fileSystem, context) { fail(it) }
     }
 }
 
@@ -90,7 +93,7 @@ fun RawArgument.outputStream(
         fileSystem: FileSystem = FileSystems.getDefault()
 ): ProcessedArgument<OutputStream, OutputStream> {
     return convert(completionCandidates = CompletionCandidates.Path) { s ->
-        convertToOutputStream(s, createIfNotExist, truncateExisting, fileSystem) { fail(it) }
+        convertToOutputStream(s, createIfNotExist, truncateExisting, fileSystem, context) { fail(it) }
     }
 }
 

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
@@ -1,6 +1,7 @@
 package com.github.ajalt.clikt.parameters.types
 
 import com.github.ajalt.clikt.completion.CompletionCandidates
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.arguments.ProcessedArgument
 import com.github.ajalt.clikt.parameters.arguments.RawArgument
 import com.github.ajalt.clikt.parameters.arguments.convert
@@ -12,10 +13,10 @@ import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 
-private fun pathType(fileOkay: Boolean, folderOkay: Boolean): String = when {
-    fileOkay && !folderOkay -> "File"
-    !fileOkay && folderOkay -> "Directory"
-    else -> "Path"
+private fun pathType(context: Context, fileOkay: Boolean, folderOkay: Boolean): String = when {
+    fileOkay && !folderOkay -> context.localization.pathTypeFile()
+    !fileOkay && folderOkay -> context.localization.pathTypeDirectory()
+    else -> context.localization.pathTypeOther()
 }
 
 internal fun convertToPath(
@@ -27,16 +28,19 @@ internal fun convertToPath(
         mustBeReadable: Boolean,
         canBeSymlink: Boolean,
         fileSystem: FileSystem,
+        context: Context,
         fail: (String) -> Unit
 ): Path {
-    val name = pathType(canBeFile, canBeFolder)
-    return fileSystem.getPath(path).also {
-        if (mustExist && !Files.exists(it)) fail("$name \"$it\" does not exist.")
-        if (!canBeFile && Files.isRegularFile(it)) fail("$name \"$it\" is a file.")
-        if (!canBeFolder && Files.isDirectory(it)) fail("$name \"$it\" is a directory.")
-        if (mustBeWritable && !Files.isWritable(it)) fail("$name \"$it\" is not writable.")
-        if (mustBeReadable && !Files.isReadable(it)) fail("$name \"$it\" is not readable.")
-        if (!canBeSymlink && Files.isSymbolicLink(it)) fail("$name \"$it\" is a symlink.")
+    val name = pathType(context, canBeFile, canBeFolder)
+    return with(context.localization) {
+        fileSystem.getPath(path).also {
+            if (mustExist && !Files.exists(it)) fail(pathDoesNotExist(name, it.toString()))
+            if (!canBeFile && Files.isRegularFile(it)) fail(pathIsFile(name, it.toString()))
+            if (!canBeFolder && Files.isDirectory(it)) fail(pathIsDirectory(name, it.toString()))
+            if (mustBeWritable && !Files.isWritable(it)) fail(pathIsNotWritable(name, it.toString()))
+            if (mustBeReadable && !Files.isReadable(it)) fail(pathIsNotReadable(name, it.toString()))
+            if (!canBeSymlink && Files.isSymbolicLink(it)) fail(pathIsSymlink(name, it.toString()))
+        }
     }
 }
 
@@ -61,7 +65,7 @@ fun RawArgument.path(
         fileSystem: FileSystem = FileSystems.getDefault()
 ): ProcessedArgument<Path, Path> {
     return convert(completionCandidates = CompletionCandidates.Path) { str ->
-        convertToPath(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, fileSystem) { fail(it) }
+        convertToPath(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, fileSystem, context) { fail(it) }
     }
 }
 
@@ -85,8 +89,7 @@ fun RawOption.path(
         canBeSymlink: Boolean = true,
         fileSystem: FileSystem = FileSystems.getDefault()
 ): NullableOption<Path, Path> {
-    val name = pathType(canBeFile, canBeDir)
-    return convert(name.toUpperCase(), completionCandidates = CompletionCandidates.Path) { str ->
-        convertToPath(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, fileSystem) { fail(it) }
+    return convert("PATH", completionCandidates = CompletionCandidates.Path) { str ->
+        convertToPath(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, fileSystem, context) { fail(it) }
     }
 }

--- a/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
+++ b/clikt/src/jvmMain/kotlin/com/github/ajalt/clikt/parameters/types/path.kt
@@ -89,7 +89,7 @@ fun RawOption.path(
         canBeSymlink: Boolean = true,
         fileSystem: FileSystem = FileSystems.getDefault()
 ): NullableOption<Path, Path> {
-    return convert("PATH", completionCandidates = CompletionCandidates.Path) { str ->
+    return convert({ localization.pathMetavar() }, CompletionCandidates.Path) { str ->
         convertToPath(str, mustExist, canBeFile, canBeDir, mustBeWritable, mustBeReadable, canBeSymlink, fileSystem, context) { fail(it) }
     }
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -234,13 +234,12 @@ and which are inherited by child commands.
 You can change these properties with the [`context`][context] builder function,
 which can be called in an `init` block, or on a command instance.
 
-For example, you can change the default help message for the `--help`
-option. These definitions are equivalent:
+For example, you can change the name of help option. These definitions are equivalent:
 
 ```kotlin tab="Version 1"
 class Cli : NoOpCliktCommand() {
     init {
-        context { helpOptionMessage = "print the help" }
+        context { helpOptionNames = setOf("/help") }
     }
 }
 fun main(args: Array<String>) = Cli()
@@ -249,7 +248,7 @@ fun main(args: Array<String>) = Cli()
 ```kotlin tab="Version 2"
 class Cli : NoOpCliktCommand()
 fun main(args: Array<String>) = Cli()
-    .context { helpOptionMessage = "print the help" }
+    .context { helpOptionNames = setOf("/help") }
     .main(args)
 ```
 

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -347,48 +347,31 @@ class Cli : NoOpCliktCommand() {
 You can localize error messages by implementing [`Localization`][Localization] and setting the
 [`localization`][Context.localization] property on your context.
 
-If you're using the default [`CliktHelpFormatter`][CliktHelpFormatter], you can localize the help output with the
-constructor parameters like `usageTitle`.
-
-
 ```kotlin tab="Example"
 class CursiveLocalization : Localization {
-    override fun usageError(message: String) = "𝐸𝓇𝓇𝑜𝓇: $message"
-    override fun noSuchOption(name: String, possibilities: List<String>) = "𝓃𝑜 𝓈𝓊𝒸𝒽 𝑜𝓅𝓉𝒾𝑜𝓃: $name"
+    override fun usageTitle() = "𝒰𝓈𝒶𝑔𝑒:"
+    override fun optionsTitle() = "𝒪𝓅𝓉𝒾𝑜𝓃𝓈:"
+    override fun optionsMetavar() = "[𝒪𝒫𝒯𝐼𝒪𝒩𝒮]:"
+    override fun helpOptionMessage() = "𝒮𝒽𝑜𝓌 𝓉𝒽𝒾𝓈 𝓂𝑒𝓈𝓈𝒶𝑔𝑒 𝒶𝓃𝒹 𝑒𝓍𝒾𝓉"
+
     // ... override the rest of the strings here
 }
 
 class I18NTool : NoOpCliktCommand(help = "𝒯𝒽𝒾𝓈 𝓉𝑜𝑜𝓁 𝒾𝓈 𝒾𝓃 𝒸𝓊𝓇𝓈𝒾𝓋𝑒") {
     init {
-        context {
-            helpOptionMessage = "𝒮𝒽𝑜𝓌 𝓉𝒽𝒾𝓈 𝓂𝑒𝓈𝓈𝒶𝑔𝑒 𝒶𝓃𝒹 𝑒𝓍𝒾𝓉"
-            helpFormatter = CliktHelpFormatter(
-                    usageTitle = "𝒰𝓈𝒶𝑔𝑒:",
-                    optionsTitle = "𝒪𝓅𝓉𝒾𝑜𝓃𝓈:",
-                    argumentsTitle = "𝒜𝓇𝑔𝓊𝓂𝑒𝓃𝓉𝓈:",
-                    commandsTitle = "𝒞𝑜𝓂𝓂𝒶𝓃𝒹𝓈:",
-                    optionsMetavar = "[𝒪𝒫𝒯𝐼𝒪𝒩𝒮]:",
-                    commandMetavar = "𝒞𝒪𝑀𝑀𝒜𝒩𝒟 [𝒜𝑅𝒢𝒮]…"
-            )
-            localization = CursiveLocalization()
-        }
+        context { localization = CursiveLocalization() }
     }
 }
 ```
 
-```text tab="Usage 1"
+```text tab="Usage"
 $ ./i18ntool --help
 𝒰𝓈𝒶𝑔𝑒: i18ntool [𝒪𝒫𝒯𝐼𝒪𝒩𝒮]
 
   𝒯𝒽𝒾𝓈 𝓉𝑜𝑜𝓁 𝒾𝓈 𝒾𝓃 𝒸𝓊𝓇𝓈𝒾𝓋𝑒
 
 𝒪𝓅𝓉𝒾𝑜𝓃𝓈:
-  -𝒽, --𝒽𝑒𝓁𝓅  𝒮𝒽𝑜𝓌 𝓉𝒽𝒾𝓈 𝓂𝑒𝓈𝓈𝒶𝑔𝑒 𝒶𝓃𝒹 𝑒𝓍𝒾𝓉
-```
-
-```text tab="Usage 2"
-$ ./i18ntool --none
-𝐸𝓇𝓇𝑜𝓇: 𝓃𝑜 𝓈𝓊𝒸𝒽 𝑜𝓅𝓉𝒾𝑜𝓃: "--none"
+  -h, --help  𝒮𝒽𝑜𝓌 𝓉𝒽𝒾𝓈 𝓂𝑒𝓈𝓈𝒶𝑔𝑒 𝒶𝓃𝒹 𝑒𝓍𝒾𝓉
 ```
 
 [CliktHelpFormatter]:       api/clikt/com.github.ajalt.clikt.output/-clikt-help-formatter/index.md

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -170,11 +170,15 @@ You can change the help option's name and help message on the
 [command's context][customizing-contexts]:
 
 ```kotlin tab="Example"
+class HelpLocalization: Localization {
+    override fun helpOptionMessage(): String = "show the help"
+}
+
 class Tool : NoOpCliktCommand() {
     init {
         context {
             helpOptionNames = setOf("/help")
-            helpOptionMessage = "show the help"
+            localization = HelpLocalization()
         }
     }
 }

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -342,11 +342,63 @@ class Cli : NoOpCliktCommand() {
 }
 ```
 
+## Localization
+
+You can localize error messages by implementing [`Localization`][Localization] and setting the
+[`localization`][Context.localization] property on your context.
+
+If you're using the default [`CliktHelpFormatter`][CliktHelpFormatter], you can localize the help output with the
+constructor parameters like `usageTitle`.
+
+
+```kotlin tab="Example"
+class CursiveLocalization : Localization {
+    override fun usageError(message: String) = "𝐸𝓇𝓇𝑜𝓇: $message"
+    override fun noSuchOption(name: String, possibilities: List<String>) = "𝓃𝑜 𝓈𝓊𝒸𝒽 𝑜𝓅𝓉𝒾𝑜𝓃: $name"
+    // ... override the rest of the strings here
+}
+
+class I18NTool : NoOpCliktCommand(help = "𝒯𝒽𝒾𝓈 𝓉𝑜𝑜𝓁 𝒾𝓈 𝒾𝓃 𝒸𝓊𝓇𝓈𝒾𝓋𝑒") {
+    init {
+        context {
+            helpOptionMessage = "𝒮𝒽𝑜𝓌 𝓉𝒽𝒾𝓈 𝓂𝑒𝓈𝓈𝒶𝑔𝑒 𝒶𝓃𝒹 𝑒𝓍𝒾𝓉"
+            helpFormatter = CliktHelpFormatter(
+                    usageTitle = "𝒰𝓈𝒶𝑔𝑒:",
+                    optionsTitle = "𝒪𝓅𝓉𝒾𝑜𝓃𝓈:",
+                    argumentsTitle = "𝒜𝓇𝑔𝓊𝓂𝑒𝓃𝓉𝓈:",
+                    commandsTitle = "𝒞𝑜𝓂𝓂𝒶𝓃𝒹𝓈:",
+                    optionsMetavar = "[𝒪𝒫𝒯𝐼𝒪𝒩𝒮]:",
+                    commandMetavar = "𝒞𝒪𝑀𝑀𝒜𝒩𝒟 [𝒜𝑅𝒢𝒮]…"
+            )
+            localization = CursiveLocalization()
+        }
+    }
+}
+```
+
+```text tab="Usage 1"
+$ ./i18ntool --help
+𝒰𝓈𝒶𝑔𝑒: i18ntool [𝒪𝒫𝒯𝐼𝒪𝒩𝒮]
+
+  𝒯𝒽𝒾𝓈 𝓉𝑜𝑜𝓁 𝒾𝓈 𝒾𝓃 𝒸𝓊𝓇𝓈𝒾𝓋𝑒
+
+𝒪𝓅𝓉𝒾𝑜𝓃𝓈:
+  -𝒽, --𝒽𝑒𝓁𝓅  𝒮𝒽𝑜𝓌 𝓉𝒽𝒾𝓈 𝓂𝑒𝓈𝓈𝒶𝑔𝑒 𝒶𝓃𝒹 𝑒𝓍𝒾𝓉
+```
+
+```text tab="Usage 2"
+$ ./i18ntool --none
+𝐸𝓇𝓇𝑜𝓇: 𝓃𝑜 𝓈𝓊𝒸𝒽 𝑜𝓅𝓉𝒾𝑜𝓃: "--none"
+```
+
+[CliktHelpFormatter]:       api/clikt/com.github.ajalt.clikt.output/-clikt-help-formatter/index.md
 [Commands]:                 api/clikt/com.github.ajalt.clikt.core/-clikt-command/index.md
+[Context.localization]:     api/clikt/com.github.ajalt.clikt.core/-context/-builder/localization.md
 [customizing-command-name]: commands.md#customizing-command-name
 [customizing-contexts]:     commands.md#customizing-contexts
 [default]:                  api/clikt/com.github.ajalt.clikt.parameters.options/default.md
 [HelpFormatter]:            api/clikt/com.github.ajalt.clikt.output/-help-formatter/index.md
+[Localization]:             api/clikt/com.github.ajalt.clikt.output/-localization/index.md
 [nel]:                      https://www.fileformat.info/info/unicode/char/0085/index.htm
 [OptionGroup]:              api/clikt/com.github.ajalt.clikt.parameters.groups/-option-group/index.md
 [provideDelegate]:          api/clikt/com.github.ajalt.clikt.parameters.groups/provide-delegate.md

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -41,7 +41,7 @@ The following subclasses exist:
 * [`UsageError`][UsageError] : The command line was incorrect in some way. All other exceptions subclass from this. These exceptions are automatically augmented with extra information about the current parameter, if possible.
 * [`ProgramResult`][ProgramResult] : The program should exit with the `statusCode` from this exception.
 * [`BadParameterValue`][BadParameterValue] : A parameter was given the correct number of values, but of invalid format or type.
-* [`MissingParameter`][MissingParameter] : A required parameter was not provided.
+* [`MissingOption`][MissingOption] and [`MissingArgument`][MissingArgument]: A required parameter was not provided.
 * [`NoSuchOption`][NoSuchOption] : An option was provided that does not exist.
 * [`NoSuchSubcommand`][NoSuchSubcommand] : A subcommand was called that does not exist.
 * [`IncorrectOptionValueCount`][IncorrectOptionValueCount] : An option was supplied but the number of values supplied to the option was incorrect.
@@ -61,7 +61,8 @@ The following subclasses exist:
 [IncorrectOptionValueCount]:       api/clikt/com.github.ajalt.clikt.core/-incorrect-option-value-count/index.md
 [InvalidFileFormat]:               api/clikt/com.github.ajalt.clikt.core/-invalid-file-format/index.md
 [main]:                            api/clikt/com.github.ajalt.clikt.core/-clikt-command/main.md
-[MissingParameter]:                api/clikt/com.github.ajalt.clikt.core/-missing-parameter/index.md
+[MissingArgument]:                 api/clikt/com.github.ajalt.clikt.core/-missing-argument/index.md
+[MissingOption]:                   api/clikt/com.github.ajalt.clikt.core/-missing-option/index.md
 [MutuallyExclusiveGroupException]: api/clikt/com.github.ajalt.clikt.core/-mutually-exclusive-group-exception/index.md
 [NoSuchOption]:                    api/clikt/com.github.ajalt.clikt.core/-no-such-option/index.md
 [NoSuchSubcommand]:                api/clikt/com.github.ajalt.clikt.core/-no-such-subcommand/index.md

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -15,4 +15,16 @@ If you still want to split option values, you can do so explicitly with [`split(
 The Value Source API and Completion Generation APIs no longer require opt-in. You can use these APIs
 without needing the `ExperimentalValueSourceApi` or `ExperimentalCompletionCandidates` annotations.
 
-[split][api/clikt/com.github.ajalt.clikt.parameters.options/split.md]
+### Localization
+
+By default, all strings are defined in the [`Localization`][Localization] object set on your
+[context][[Context.localization]. This means that string parameters like `usageTitle` in the
+constructor for [`CliktHelpFormatter`][CliktHelpFormatter] have been removed in favor of functions like
+[`Localization.usageTitle()`][Localization.usageTitle].
+
+
+[CliktHelpFormatter]:       api/clikt/com.github.ajalt.clikt.output/-clikt-help-formatter/index.md
+[Context.localization]:     api/clikt/com.github.ajalt.clikt.core/-context/-builder/localization.md
+[Localization]:             api/clikt/com.github.ajalt.clikt.output/-localization/index.md
+[Localization.usageTitle]:  api/clikt/com.github.ajalt.clikt.output/-localization/usage-title.md
+[split]:                    api/clikt/com.github.ajalt.clikt.parameters.options/split.md

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -18,13 +18,21 @@ without needing the `ExperimentalValueSourceApi` or `ExperimentalCompletionCandi
 ### Localization
 
 By default, all strings are defined in the [`Localization`][Localization] object set on your
-[context][[Context.localization]. This means that string parameters like `usageTitle` in the
-constructor for [`CliktHelpFormatter`][CliktHelpFormatter] have been removed in favor of functions like
+[context][[Context.localization]. 
+
+This means that string parameters like `usageTitle` in the constructor for
+[`CliktHelpFormatter`][CliktHelpFormatter] have been removed in favor of functions like
 [`Localization.usageTitle()`][Localization.usageTitle].
 
+`Context.helpOptionMessage` has also been removed in favor of
+[`Localization.helpOptionMessage()`][Localization.helpOptionMessage]. See [Help Option
+Customization][help-option-custom] for an example.
 
-[CliktHelpFormatter]:       api/clikt/com.github.ajalt.clikt.output/-clikt-help-formatter/index.md
-[Context.localization]:     api/clikt/com.github.ajalt.clikt.core/-context/-builder/localization.md
-[Localization]:             api/clikt/com.github.ajalt.clikt.output/-localization/index.md
-[Localization.usageTitle]:  api/clikt/com.github.ajalt.clikt.output/-localization/usage-title.md
-[split]:                    api/clikt/com.github.ajalt.clikt.parameters.options/split.md
+
+[CliktHelpFormatter]:               api/clikt/com.github.ajalt.clikt.output/-clikt-help-formatter/index.md
+[Context.localization]:             api/clikt/com.github.ajalt.clikt.core/-context/-builder/localization.md
+[help-option-custom]:               documenting.md#help-option-customization
+[Localization]:                     api/clikt/com.github.ajalt.clikt.output/-localization/index.md
+[Localization.usageTitle]:          api/clikt/com.github.ajalt.clikt.output/-localization/usage-title.md
+[Localization.helpOptionMessage]:   api/clikt/com.github.ajalt.clikt.output/-localization/help-option-message.md
+[split]:                            api/clikt/com.github.ajalt.clikt.parameters.options/split.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
       - 'Required Options in Help': documenting/#required-options-in-help
       - 'Grouping Options in Help': documenting/#grouping-options-in-help
       - 'Suggesting Corrections for Mistyped Parameters': documenting/#suggesting-corrections-for-mistyped-parameters
+      - 'Localization': documenting/#localization
   - 'Advanced Patterns':
       - 'Command Aliases': advanced/
       - 'Token Normalization': advanced/#token-normalization

--- a/samples/helpformat/src/main/kotlin/com/github/ajalt/clikt/samples/helpformat/main.kt
+++ b/samples/helpformat/src/main/kotlin/com/github/ajalt/clikt/samples/helpformat/main.kt
@@ -4,19 +4,25 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.output.CliktHelpFormatter
 import com.github.ajalt.clikt.output.HelpFormatter
+import com.github.ajalt.clikt.output.Localization
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 
-class ArgparseHelpFormatter : CliktHelpFormatter(
-        usageTitle = "usage:",
-        optionsTitle = "optional arguments:",
-        argumentsTitle = "positional arguments:") {
-    override fun formatHelp(prolog: String,
-                            epilog: String,
-                            parameters: List<HelpFormatter.ParameterHelp>,
-                            programName: String) = buildString {
+class ArgparseLocalization : Localization {
+    override fun usageTitle(): String = "usage:"
+    override fun optionsTitle(): String = "optional arguments:"
+    override fun argumentsTitle(): String = "positional arguments:"
+}
+
+class ArgparseHelpFormatter : CliktHelpFormatter(ArgparseLocalization()) {
+    override fun formatHelp(
+            prolog: String,
+            epilog: String,
+            parameters: List<HelpFormatter.ParameterHelp>,
+            programName: String
+    ) = buildString {
         // argparse prints arguments before options
         addUsage(parameters, programName)
         addProlog(prolog)


### PR DESCRIPTION
Here's my first stab at supporting i18n of Clikt output.

All exceptions and conversions now pull their strings from a `Localization` object configured on the current context. Right now, that object is an interface with all default methods. This should allow me to add strings in the future without breaking ABI compatibility. I kept all logic other than simple string interpolation out of the `Localization` implementation, although that leads to some weirdness when dealing with plurals and lists values.

For example, the error message when too many arguments are present is currently split into two:

```kotlin
fun extraArgumentOne(name: String) = "Got unexpected extra argument $name"
fun extraArgumentMany(name: String, count: Int) = "Got unexpected extra arguments $name"
```

But languages that pluralize differently than english will need to add some logic to `extraArgumentMany` anyway, so maybe it's better to combine those two functions.

Joining sentences together is also introduces some redundancy. For example, the error when you type an option that doesn't exist might include typo corrections. Right now, there are two functions:

```kotlin
fun noSuchOption(name: String) = "no such option: $name"
fun noSuchOption(name: String, suggestion: String) = "no such option: $name. $suggestion"
```

Maybe it would be better to make the `suggestion` parameter nullable and let the implementations deal with it?


The last problem is when joining lists. For example, the suggestions for typo correction are a list of names. Right now the prefix and postfix are separate strings, and the caller joins them:

```kotlin
fun possibleOptionsPrefix() = "(Possible options: "
fun possibleParameterPostfix() = ")"
```

That feels clunky. Maybe it would be better to just pass in the list of items and have the implementation join them?


Finally, there are a couple of places that define strings that aren't in the `Localization`. The `CliktHelpFormatter` has a few constructor parameters for things like the `usageTitle`. We could read those from `Localization`, but other help formatters might not need those strings, so maybe it's better to leave them separate.


The other place that doesn't read from `Localization` is the `metavar` parameters to `option()` and `convert()`. There's no context at the time options are defined, so I'm not sure what to do here. We could change the parameter from `String` to `(Context) -> String`, although that's kind of clunky. As-is, you'll have to manually specify the metavar for every option if you want it localized.

Fixes #227 