### PR TITLE
Make CompletionGenerator non-internal

### DIFF
--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
@@ -3,7 +3,7 @@ package com.github.ajalt.clikt.completion
 import com.github.ajalt.clikt.completion.CompletionCandidates.Custom.ShellType
 import com.github.ajalt.clikt.core.CliktCommand
 
-internal object CompletionGenerator {
+object CompletionGenerator {
     fun generateCompletion(command: CliktCommand, zsh: Boolean = true): String {
         val commandName = command.commandName
         val (isTopLevel, funcName) = commandCompletionFuncName(command)

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
@@ -4,7 +4,7 @@ import com.github.ajalt.clikt.completion.CompletionCandidates.Custom.ShellType
 import com.github.ajalt.clikt.core.CliktCommand
 
 object CompletionGenerator {
-    fun generateCompletion(command: CliktCommand, zsh: Boolean = true): String {
+    internal fun generateCompletion(command: CliktCommand, zsh: Boolean = true): String {
         val commandName = command.commandName
         val (isTopLevel, funcName) = commandCompletionFuncName(command)
         val options = command._options.map { Triple(it.names, it.completionCandidates, it.nvalues) }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
@@ -8,6 +8,10 @@ object CompletionGenerator {
         return generateCompletion(command, zsh = false)
     }
 
+    fun generateZshCompletion(command: CliktCommand): String {
+        return generateCompletion(command, zsh = true)
+    }
+
     internal fun generateCompletion(command: CliktCommand, zsh: Boolean = true): String {
         val commandName = command.commandName
         val (isTopLevel, funcName) = commandCompletionFuncName(command)

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/CompletionGenerator.kt
@@ -4,6 +4,10 @@ import com.github.ajalt.clikt.completion.CompletionCandidates.Custom.ShellType
 import com.github.ajalt.clikt.core.CliktCommand
 
 object CompletionGenerator {
+    fun generateBashCompletion(command: CliktCommand): String {
+        return generateCompletion(command, zsh = false)
+    }
+
     internal fun generateCompletion(command: CliktCommand, zsh: Boolean = true): String {
         val commandName = command.commandName
         val (isTopLevel, funcName) = commandCompletionFuncName(command)


### PR DESCRIPTION
This enables individual generation of the completion.
For example, I would like to provide a separate command for it, such as [kubectl](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#completion) / [helm](https://helm.sh/docs/helm/helm_completion/).

```kotlin
class CompletionCommand : CliktCommand(
    name = "completion",
    help = "Generate completion script."
) {

    val shell by argument("SHELL").choice("bash", "zsh")

    override fun run() {
        val completion = CompletionGenerator.generateCompletion(command = this, zsh = "zsh" == shell)
        throw PrintCompletionMessage(completion, forceUnixLineEndings = true)
    }

}
```