### PR TITLE
Add Maven installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,25 @@ them with the included [`runsample` script](runsample).
 
 Clikt is distributed through [Maven Central](https://search.maven.org/artifact/com.github.ajalt.clikt/clikt).
 
+ <sup>In version 3.0, the maven coordinates changed. Make sure you're using the new coordinates if you're updating from an older version.</sup>
+
+#### Gradle
+
 ```groovy
 dependencies {
    implementation("com.github.ajalt.clikt:clikt:3.1.0")
 }
 ```
- <sup>In version 3.0, the maven coordinates changed. Make sure you're using the new coordinates if you're updating from an older version.</sup>
+
+#### Maven
+
+```xml
+<dependency>
+    <groupId>com.github.ajalt.clikt</groupId>
+    <artifactId>clikt-jvm</artifactId>
+    <version>3.1.0</version>
+</dependency>
+```
 
 #### Multiplatform
 Clikt supports the following targets: `jvm`, `mingwX64`, `linuxX64`, `macosX64`, and `js` (for both


### PR DESCRIPTION
Firstly, thanks for the wonderful library!

Here, I'm adding a readme note to use the clikt-jvm artifact for the Maven dependency.

This was suggested in: https://github.com/ajalt/clikt/issues/235#issuecomment-686817047