### PR TITLE
Create a runsample script for Windows

### DIFF
--- a/runsample
+++ b/runsample
@@ -6,11 +6,10 @@
 task=$1
 shift 1
 
-if [ ! -d "samples/${task}" ]; then
-    echo "Unknown sample ${task}"
+if [ -z "${task}" ] || [ ! -d "samples/${task}" ]
+then
+    echo "Unknown sample: '${task}'"
     exit 1
 fi
 
-./gradlew --quiet :samples:${task}:installDist
-
-./samples/${task}/build/install/${task}/bin/${task} "$@"
+./gradlew --quiet ":samples:${task}:installDist" && "./samples/${task}/build/install/${task}/bin/${task}" "$@"

--- a/runsample.bat
+++ b/runsample.bat
@@ -7,11 +7,10 @@ if "%OS%"=="Windows_NT" setlocal EnableDelayedExpansion
 
 set TASK=%~1
 
-set UNKNOWN_SAMPLE=false
-if "%TASK: =%"==""            set UNKNOWN_SAMPLE=true
-if not exist "samples\%TASK%" set UNKNOWN_SAMPLE=true
+set SAMPLE=false
+if defined TASK if not "!TASK: =!"=="" if exist "samples\%TASK%" set SAMPLE=true
 
-if "%UNKNOWN_SAMPLE%"=="true" (
+if "%SAMPLE%"=="false" (
     echo Unknown sample: '%TASK%'
     exit /b 1
 )

--- a/runsample.bat
+++ b/runsample.bat
@@ -1,0 +1,25 @@
+@if "%DEBUG%"=="" @echo off
+:: Run one of the samples.
+:: The first argument must be the name of the sample task (e.g. echo).
+:: Any remaining arguments are forwarded to the sample's argv.
+
+if "%OS%"=="Windows_NT" setlocal EnableDelayedExpansion
+
+set TASK=%~1
+
+set UNKNOWN_SAMPLE=false
+if "%TASK: =%"==""            set UNKNOWN_SAMPLE=true
+if not exist "samples\%TASK%" set UNKNOWN_SAMPLE=true
+
+if "%UNKNOWN_SAMPLE%"=="true" (
+    echo Unknown sample: '%TASK%'
+    exit /b 1
+)
+
+set ARGS=%*
+set ARGS=!ARGS:*%1=!
+if "!ARGS:~0,1!"==" " set ARGS=!ARGS:~1!
+
+call gradlew --quiet ":samples:%TASK%:installDist" && call "samples\%TASK%\build\install\%TASK%\bin\%TASK%" %ARGS%
+
+if "%OS%"=="Windows_NT" endlocal

--- a/runsample.bat
+++ b/runsample.bat
@@ -8,7 +8,7 @@ if "%OS%"=="Windows_NT" setlocal EnableDelayedExpansion
 set TASK=%~1
 
 set SAMPLE=false
-if defined TASK if not "!TASK: =!"=="" if exist "samples\%TASK%" set SAMPLE=true
+if defined TASK if not "!TASK: =!"=="" if exist "samples\%TASK%\*" set SAMPLE=true
 
 if "%SAMPLE%"=="false" (
     echo Unknown sample: '%TASK%'


### PR DESCRIPTION
For those of us still using Windows without WSL, B4W...

While I was at it, I've also fixed a few shellcheck warnings in the original runsample script and made it exit upon encountering an empty string.