### PR TITLE
Revert "Update kotlin to 1.4.30" due to KT-44826

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 ### Changed
 - Make parameters of `mutuallyExclusiveOptions` covariant to allow validation without explicit type annotations. ([#265](https://github.com/ajalt/clikt/issues/265))
-- Update kotlin to 1.4.30
 
 ### Fixed
 - Reading from an option or argument property on a command that hasn't been invoked will now always throw an `IllegalStateException`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import java.io.ByteArrayOutputStream
 val VERSION_NAME: String by project
 
 plugins {
-    kotlin("jvm").version("1.4.30")
+    kotlin("jvm").version("1.4.21")
     id("org.jetbrains.dokka").version("0.10.1")
 }
 


### PR DESCRIPTION
This reverts commit 07b8c646963d45e8ad0597cf0f4b61d246d18827.

An apparent bug in Kotlin 1.4.30 is causing macOS builds to fail, so
we're downgrading back to an older version of Kotlin until it's fixed.

Bug reported here: https://youtrack.jetbrains.com/issue/KT-44826