### PR TITLE
 Report error when excess arguments are given to a command with `allowMultipleSubcommands=true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Updated kotlin to 1.5.10
 
+### Fixed
+- Report error when excess arguments are given to a command with `allowMultipleSubcommands=true`
+
 ## 3.2.0
 _2021-05-14_
 

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/SubcommandTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/SubcommandTest.kt
@@ -396,6 +396,17 @@ class SubcommandTest {
     }
 
     @Test
+    @JsName("multiple_subcommands_with_excess_arguments")
+    fun `multiple subcommands with excess arguments`() {
+        val sub = TestCommand(name = "sub", called = true)
+        val c = TestCommand(allowMultipleSubcommands = true).subcommands(sub)
+        shouldThrow<UsageError> {
+            c.parse("sub foo")
+        }.message shouldBe "Got unexpected extra argument (foo)"
+    }
+
+
+    @Test
     @JsName("accessing_options_of_uninvoked_subcommand")
     fun `accessing options of uninvoked subcommand`() {
         class Sub(name: String, called: Boolean) : TestCommand(called, name = name) {


### PR DESCRIPTION
Fixes #303 