### PR TITLE
Added obj to Context.Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Added
+- Added `obj` to `Context.Builder` which allows to initialize a context with an arbitrary `obj`
+
 ## 3.3.0
 ### Added
 - Added `default` parameter to `argument().multiple()` ([#305](https://github.com/ajalt/clikt/issues/305))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
@@ -191,6 +191,15 @@ class Context @JvmOverloads constructor(
          * You can set this to read from a map or other source during tests.
          */
         var envvarReader: (key: String) -> String? = parent?.readEnvvar ?: ::readEnvvar
+
+        /**
+         * Initialize the context with an arbitrary `obj`.
+         *
+         * This is a convenient way to assign an arbitrary `obj` without needing to instantiate/configure multiple
+         * nested commands. This can help to isolate tests of subcommands which expect an ancestor command to have
+         * assigned an `obj`.
+         */
+        var obj: Any? = parent?.obj
     }
 
     companion object {
@@ -214,7 +223,7 @@ class Context @JvmOverloads constructor(
                     helpOptionNames, formatter, tokenTransformer, console, expandArgumentFiles,
                     readEnvvarBeforeValueSource, valueSource, correctionSuggestor, localization,
                     envvarReader, argv
-                )
+                ).also { it.obj = obj }
             }
         }
     }

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/ContextTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/ContextTest.kt
@@ -87,6 +87,20 @@ class ContextTest {
     }
 
     @Test
+    @JsName("assign_obj_through_context_builder")
+    fun `assign obj through context builder`() {
+        val foo = Foo()
+        val c = TestCommand()
+            .context {
+                obj = foo
+            }
+
+        c.parse("")
+
+        foo shouldBeSameInstanceAs c.currentContext.obj
+    }
+
+    @Test
     @JsName("default_help_option_names")
     fun `default help option names`() {
         class C : TestCommand()


### PR DESCRIPTION
Adds `obj` to `Context.Builder` which allows to initialize a context with an arbitrary `obj`