### PR TITLE
Make help output match the code sample

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -119,7 +119,7 @@ delegates:
 === "Help Output"
     ```text
     $ ./hello --help
-    Usage: hello [OPTIONS] USERNAME
+    Usage: hello [OPTIONS] NAME
 
     Options:
       --count INT  Number of greetings


### PR DESCRIPTION
The code snippet uses `val name by argument()`. So the help output will contain `NAME`, not `USERNAME`.