### PR TITLE
Allow single-dash options as unknown

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,16 @@ jobs:
           name: error-report
           path: build-reports.zip
   deploy:
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest ]
+        include:
+          - os: macos-latest
+            DEPLOY_TASK: :clikt:publishMacosX64PublicationToMavenRepository
+          - os: ubuntu-latest
+            DEPLOY_TASK: publish
     needs: test
-    runs-on: macos-latest
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - name: Fetch git tags
@@ -62,7 +70,7 @@ jobs:
           java-version: 11
       - uses: gradle/gradle-build-action@v2
         with:
-          arguments: publish --stacktrace -PinferVersion=true
+          arguments: ${{matrix.DEPLOY_TASK}} --stacktrace -PinferVersion=true
 
 env:
   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=true -Dkotlin.incremental=false -Dorg.gradle.project.kotlin.incremental.multiplatform=false -Dorg.gradle.project.kotlin.native.disableCompilerDaemon=true -Dorg.gradle.jvmargs="-Xmx5g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ macos-latest,  windows-latest, ubuntu-latest ]
+        os: [ macos-latest, windows-latest, ubuntu-latest ]
         include:
           - os: macos-latest
             TEST_TASK: macosX64Test

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/Parser.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/Parser.kt
@@ -283,7 +283,7 @@ internal object Parser {
             if (i == 0) continue // skip the dash
 
             val name = context.tokenTransformer(context, prefix + opt)
-            val option = optionsByName[name] ?: if (ignoreUnknown && tok.length == 2) {
+            val option = optionsByName[name] ?: if (ignoreUnknown) {
                 return OptParseResult(1, listOf(tok), emptyList())
             } else {
                 val possibilities = when {


### PR DESCRIPTION
If `treatUnknownOptionsAsArgs` is set to `true` the parser only ignores single-dash single-letter (example: `-x`) options, but not `-abcdefgh` style options. 

This is useful if the options are passed to another program as-is.

This PR changes the behavior accordingly.