### PR TITLE
Support grouped short options with treatUnknownOptionsAsArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+## Changed
+- When using `treatUnknownOptionsAsArgs`, grouped short options like `-abc` will be treated as an argument rather than reporting an error as long as they don't match any short options in the command. ([#340](https://github.com/ajalt/clikt/pull/340))
 ## 3.4.2
 ### Deprecated
 - `TermUi.echo`, `TermUi.prompt`, and `TermUi.confirm`. Use the equivalent methods on `CliktCommand` instead. ([#344](https://github.com/ajalt/clikt/issues/344))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/Parser.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/Parser.kt
@@ -283,7 +283,7 @@ internal object Parser {
             if (i == 0) continue // skip the dash
 
             val name = context.tokenTransformer(context, prefix + opt)
-            val option = optionsByName[name] ?: if (ignoreUnknown && tok.length == 2) {
+            val option = optionsByName[name] ?: if (ignoreUnknown && i == 1) {
                 return OptParseResult(1, listOf(tok), emptyList())
             } else {
                 val possibilities = when {

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/completion/CompletionTestBase.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/completion/CompletionTestBase.kt
@@ -22,12 +22,7 @@ abstract class CompletionTestBase(private val shell: String) {
         val message = shouldThrow<PrintCompletionMessage> {
             command.parse("--generate-completion=$shell")
         }.message
-        try {
-            assertEquals(expected.trimMargin(), message)
-        } catch (e: Throwable) {
-            println(message)
-            throw e
-        }
+        assertEquals(expected.trimMargin(), message)
     }
 
     @JsName("custom_completions_expected")

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
@@ -258,10 +258,16 @@ class CliktCommandTest {
             val args by argument().multiple()
         }
 
-        val c = C(true)
-        c.parse("-f -g -i")
-        c.foo shouldBe true
-        c.args shouldBe listOf("-g", "-i")
+        with(C(true)) {
+            parse("-f -g -i")
+            foo shouldBe true
+            args shouldBe listOf("-g", "-i")
+        }
+        with(C(true)) {
+            parse("-f -gi")
+            foo shouldBe true
+            args shouldBe listOf("-gi")
+        }
         shouldThrow<NoSuchOption> {
             C(false).parse("-fgi")
         }.message shouldBe "no such option: \"-g\""

--- a/docs/options.md
+++ b/docs/options.md
@@ -825,13 +825,13 @@ property to collect the options, otherwise an error will still be reported.
     class Wrapper : CliktCommand(treatUnknownOptionsAsArgs = true) {
         init { context { allowInterspersedArgs = false } }
 
-        val command by option(help = "?").required()
+        val command by option().required()
         val arguments by argument().multiple()
 
         override fun run() {
             val cmd = (listOf(command) + arguments).joinToString(" ")
             val proc = Runtime.getRuntime().exec(cmd)
-            println(proc.inputStream.bufferedReader().readText())
+            echo(proc.inputStream.bufferedReader().readText())
             proc.waitFor()
         }
     }
@@ -846,9 +846,11 @@ property to collect the options, otherwise an error will still be reported.
            git-tag - Create, list, delete or verify a tag object signed with GPG
     ```
 
-Note that flag options in a single token (e.g. using `-abc` to specify `-a`, `-b`, and `-c` in a
-single token) will still report an error if they are unknown. Each option should be specified
-separately in this mode.
+!!! warning
+
+    Multiple short options in a single token (e.g. using `-abc` to specify `-a`, `-b`, and `-c` in a single token) will
+    still report an error if it contains a mixture of known and unknown options. To avoid this, don't declare single-letter
+    names for options in commands that use `treatUnknownOptionsAsArgs`.
 
 You'll often want to set [`allowInterspersedArgs = false`][allowInterspersedArgs] on your Context when
 using `treatUnknownOptionsAsArgs`. You may also find that subcommands are a better fit than

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,8 +28,10 @@ markdown_extensions:
   - meta
   - toc:
       permalink: true
+  - admonition
   - pymdownx.betterem:
       smart_enable: all
+  - pymdownx.details
   - pymdownx.caret
   - pymdownx.inlinehilite
   - pymdownx.magiclink


### PR DESCRIPTION
As long as a token doesn't start with a known option name, we will now treat the entire token as unknown. If the token starts with a known short option letter, we still report an error as before.

Fixes #339