### PR TITLE
Add CliktConsole parameter to TermUi.prompt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
           path: build-reports.zip
   deploy:
     needs: test
-    runs-on: macos-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
       - name: Fetch git tags


### PR DESCRIPTION
When writing unit tests for my ClickCommand which is using `TermUi.prompt() : String?`, I realized that it was impossible to set a custom CliktConsole to it, so I'm adding it.

Please let me know if I missed something on how to contribute to this awesome project!