### PR TITLE
Use GetEnvironmentVariableW instead of getenv on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Support unicode in environment variable values on Native Windows. ([#362](https://github.com/ajalt/clikt/issues/362))
+
 ## 3.5.0
 ### Added
 - Added `hidden` parameter to `CliktCommand`, which will prevent the command from being displayed as a subcommand in help output  ([#353](https://github.com/ajalt/clikt/issues/353))

--- a/clikt/src/linuxX64Main/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
+++ b/clikt/src/linuxX64Main/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
@@ -1,0 +1,6 @@
+package com.github.ajalt.clikt.mpp
+
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+
+internal actual fun readEnvvar(key: String): String? = getenv(key)?.toKString()

--- a/clikt/src/mingwX64Main/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
+++ b/clikt/src/mingwX64Main/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
@@ -1,0 +1,39 @@
+package com.github.ajalt.clikt.mpp
+
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toKStringFromUtf16
+import platform.windows.GetEnvironmentVariableW
+import platform.windows.LPWSTR
+
+// value from https://docs.microsoft.com/en-us/windows/win32/api/processenv/nf-processenv-getenvironmentvariablew
+const val MAX_ENVVAR_SIZE = 32768u
+
+/**
+ * Windows has whopping 6 different functions to read environment variables:
+ * - GetEnvironmentVariableA, GetEnvironmentVariableW, getenv, _wgetenv, getenv_s, _wgetenv_s
+ *
+ * As discussed in [https://github.com/curl/curl/issues/4774], environment variables set via SetEnvironmentVariable are
+ * visible to GetEnvironmentVariable but not to getenv. So we don't want to use any of the getenv variants.
+ *
+ * Additionally, we don't want to use GetEnvironmentVariableA, because it doesn't support unicode.
+ *
+ * The code in this function is a port of the example shown in
+ * [https://docs.microsoft.com/en-us/windows/win32/procthread/changing-environment-variables] with the realloc loop
+ * inspired by [https://github.com/curl/curl/pull/4863/files]
+ */
+internal actual fun readEnvvar(key: String): String? {
+    var bufSize = MAX_ENVVAR_SIZE
+    while (true) {
+        memScoped {
+            val buffer: LPWSTR = allocArray(bufSize.toLong())
+            val readSize = GetEnvironmentVariableW(key, buffer, bufSize)
+            when {
+                // We don't bother checking GetLastError() since ENVVAR_NOT_FOUND is the only documented error value.
+                readSize == 0u -> return null // envvar doesn't exist
+                readSize > bufSize -> bufSize = readSize // buffer too small, realloc
+                else -> return buffer.toKStringFromUtf16() // success
+            }
+        }
+    }
+}

--- a/clikt/src/nativeDarwinMain/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
+++ b/clikt/src/nativeDarwinMain/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
@@ -1,0 +1,6 @@
+package com.github.ajalt.clikt.mpp
+
+import kotlinx.cinterop.toKString
+import platform.posix.getenv
+
+internal actual fun readEnvvar(key: String): String? = getenv(key)?.toKString()

--- a/clikt/src/nativeMain/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
+++ b/clikt/src/nativeMain/kotlin/com/github/ajalt/clikt/mpp/MppImpl.kt
@@ -16,8 +16,6 @@ internal actual val String.graphemeLengthMpp: Int get() = replace(ANSI_CODE_RE, 
 
 internal actual fun isLetterOrDigit(c: Char): Boolean = LETTER_OR_DIGIT_RE.matches(c.toString())
 
-internal actual fun readEnvvar(key: String): String? = getenv(key)?.toKString()
-
 internal actual fun isWindowsMpp(): Boolean = Platform.osFamily == OsFamily.WINDOWS
 
 internal actual fun exitProcessMpp(status: Int): Unit = exitProcess(status)


### PR DESCRIPTION
Fixes #362