### PR TITLE
Docs: Fix bullet lists being displayed as a single paragraph.

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -374,6 +374,7 @@ Clikt supports the following platforms in addition to JVM:
 ### Desktop native (Linux, Windows, and MacOS)
 
 All functionality is supported, except:
+
 * `env` parameter of [editText][editText] and [editFile][editFile] is ignored.
 * `hideInput` parameter of [prompt][prompt] is ignored.
 * [file][file] and [path][path] parameter types are not supported.
@@ -381,12 +382,14 @@ All functionality is supported, except:
 ### NodeJS
 
 All functionality is supported, except:
+
 * `hideInput` parameter of [prompt][prompt] is ignored.
 * [file][file] and [path][path] parameter types are not supported.
 
 ### Browser JavaScript
 
 All functionality is supported, except:
+
 * The default [CliktConsole][CliktConsole] only outputs to the browser's developer console, which is
 probably not what you want. You can [define your own CliktConsole](#replacing-stdin-and-stdout), or
 you can call [parse][parse] instead of [main][main] and handle output yourself.


### PR DESCRIPTION
When rendered with MkDocs, some bullet lists were not displayed as a list, but as a single paragraph of text.
MkDocs seems to be stricter about Markdown formatting here, compared to GitHub.