### PR TITLE
Add MordantHelpFormatter.renderAttachedOptionValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Added
+- Added `MordantHelpFormatter.renderAttachedOptionValue` that you can override to change how option values are shown, e.g. if you want option to show as `--option <value>` instead of `--option=<value>`. ([#416](https://github.com/ajalt/clikt/issues/416))
+
 ## 4.0.0
 ### Added
 - Added `Context.errorEncountered` which is true if parsing has continued after an error was encountered.

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/MordantHelpFormatter.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/MordantHelpFormatter.kt
@@ -312,6 +312,7 @@ open class MordantHelpFormatter(
 
     protected open fun renderOptionalMetavar(metavar: String): String = "[$metavar]"
     protected open fun renderRepeatedMetavar(metavar: String): String = "$metavar..."
+    protected open fun renderAttachedOptionValue(metavar: String) = "=$metavar"
 
     protected open fun renderOptionValue(option: ParameterHelp.Option): String {
         if (option.metavar == null) return ""
@@ -319,10 +320,11 @@ open class MordantHelpFormatter(
         if ('|' !in metavar) metavar = normalizeParameter(metavar)
         metavar = styleMetavar(metavar)
         if (option.nvalues.last > 1) metavar = renderRepeatedMetavar(metavar)
-        metavar = "=$metavar"
+        metavar = renderAttachedOptionValue(metavar)
         if (option.nvalues.first == 0) metavar = renderOptionalMetavar(metavar)
         return metavar
     }
+
 
     protected open fun renderDefinitionTerm(row: DefinitionRow): Widget {
         val termPrefix = when {

--- a/samples/helpformat/src/main/kotlin/com/github/ajalt/clikt/samples/helpformat/main.kt
+++ b/samples/helpformat/src/main/kotlin/com/github/ajalt/clikt/samples/helpformat/main.kt
@@ -31,6 +31,9 @@ class PanelHelpFormatter(context: Context) : MordantHelpFormatter(context) {
     // Print metavars like INT instead of <int>
     override fun normalizeParameter(name: String): String = name.uppercase()
 
+    // Print option values like `--option VALUE instead of `--option=VALUE`
+    override fun renderAttachedOptionValue(metavar: String): String = " $metavar"
+
     // Put each parameter section in its own panel
     override fun renderParameters(
         parameters: List<HelpFormatter.ParameterHelp>,


### PR DESCRIPTION
You could already do this by overriding `renderOptionValue`, but that would require copying a couple of lines of code, so `renderAttachedOptionValue` is easier if all you want to change is the `=` to a space.

Fixes #416