### PR TITLE
samples: Remove `RequiresOptIn` which is not required anymore

### DIFF
--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -7,10 +7,4 @@ subprojects {
     dependencies {
         "implementation"(project(":clikt"))
     }
-
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
-        }
-    }
 }


### PR DESCRIPTION
Also, the `-Xopt-in` syntax is deprecated anyway. This avoids a compiler warning.