### PR TITLE
Gradle: Use the new Kotlin/JS IR backend

### DIFF
--- a/clikt/build.gradle.kts
+++ b/clikt/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 kotlin {
     jvm()
-    js {
+    js(IR) {
         nodejs()
         browser()
     }


### PR DESCRIPTION
This reduces bundle size and auto-generates TypeScript definitions, see https://kotlinlang.org/docs/js-ir-compiler.html.