### PR TITLE
Fix error message when lazily referencing required options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Fixed
+- Fixed incorrect error message when a `defaultLazy` option referenced a `required` option. ([#430](https://github.com/ajalt/clikt/issues/430))
+
 ## 4.1.0
 ### Added
 - Added `MordantHelpFormatter.renderAttachedOptionValue` that you can override to change how option values are shown, e.g. if you want option to show as `--option <value>` instead of `--option=<value>`. ([#416](https://github.com/ajalt/clikt/issues/416))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/internal/Finalization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/internal/Finalization.kt
@@ -43,13 +43,15 @@ internal fun finalizeOptions(
     for (o in retries) {
         try {
             o.finalize(context, emptyList())
+        } catch (e: IllegalStateException) {
+            // If we had an earlier usage error, throw that instead of the ISE
+            MultiUsageError.buildOrNull(errors)?.let { throw it }
+            throw e
         } catch (e: UsageError) {
             errors += e
             context.errorEncountered = true
         }
     }
 
-    MultiUsageError.buildOrNull(errors)?.let {
-        throw it
-    }
+    MultiUsageError.buildOrNull(errors)?.let { throw it }
 }

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
@@ -427,6 +427,20 @@ class OptionTest {
         C().parse("")
     }
 
+
+    @Test
+    @JsName("defaultLazy_option_referencing_required_option")
+    fun `defaultLazy option referencing required option`() {
+        class C : TestCommand(called = false) {
+            val y by option().defaultLazy { x }
+            val x by option().required()
+        }
+
+        shouldThrow<MissingOption> {
+            C().parse("")
+        }.formattedMessage shouldBe "missing option --x"
+    }
+
     @Test
     @JsName("defaultLazy_option_referencing_argument")
     fun `defaultLazy option referencing argument`() {


### PR DESCRIPTION
In order to support referencing other options in `defaultLazy`, we call `finalize` twice if the first call caused an IllegalStateException. The second time happens after all other options are finalized, so as long as there are no reference cycles or chains, the second call will succeed.

In order to support MultiUsageError, we have to collect all UsageErrors until after the second finalization round.

The regression happened because we were throwing IllegalStateExceptions that occur in the second round even if there were deferred UsageErrors.

Fixes #430 