### PR TITLE
Remove obsolete OptIn usage

### DIFF
--- a/clikt/build.gradle.kts
+++ b/clikt/build.gradle.kts
@@ -19,10 +19,6 @@ kotlin {
     macosArm64()
 
     sourceSets {
-        all {
-            languageSettings.optIn("kotlin.RequiresOptIn")
-        }
-
         val commonMain by getting {
             dependencies {
                 api(libs.mordant)

--- a/clikt/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/OutputStreamTest.kt
+++ b/clikt/src/jvmTest/kotlin/com/github/ajalt/clikt/parameters/types/OutputStreamTest.kt
@@ -23,7 +23,6 @@ import kotlin.test.Test
 
 
 @Suppress("unused")
-@OptIn(ExperimentalStdlibApi::class)
 class OutputStreamTest {
     @get:Rule
     val stdout: SystemOutRule = SystemOutRule().enableLog()


### PR DESCRIPTION
As of Kotlin 1.7 the opt-in feature is now stable and does not need an explicit declaration.

https://kotlinlang.org/docs/whatsnew17.html#stable-opt-in-requirements