### PR TITLE
Allow `CliktCommand.test` to take a `vararg`

### DIFF
--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/testing/CliktTesting.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/testing/CliktTesting.kt
@@ -8,6 +8,7 @@ import com.github.ajalt.clikt.parsers.shlex
 import com.github.ajalt.mordant.rendering.AnsiLevel
 import com.github.ajalt.mordant.terminal.Terminal
 import com.github.ajalt.mordant.terminal.TerminalRecorder
+import kotlin.jvm.JvmName
 
 data class CliktCommandTestResult(
     /** Standard output captured from the command */
@@ -52,6 +53,33 @@ fun CliktCommand.test(
     return test(argvArray, stdin, envvars, includeSystemEnvvars, ansiLevel, width, height)
 }
 
+/**
+ * Test this command, returning a result that captures the output and result status code.
+ *
+ * Note that only output printed with [echo][CliktCommand.echo] will be captured. Anything printed with [print] or
+ * [println] is not.
+ *
+ * @param argv The command line to send to the command
+ * @param stdin Content of stdin that will be read by prompt options. Multiple inputs should be separated by `\n`.
+ * @param envvars A map of environment variable name to value for envvars that can be read by the command
+ * @param includeSystemEnvvars Set to true to include the environment variables from the system in addition to those
+ *   defined in [envvars]
+ * @param ansiLevel Defaults to no colored output; set to [AnsiLevel.TRUECOLOR] to include ANSI codes in the output.
+ * @param width The width of the terminal, used to wrap text
+ * @param height The height of the terminal
+ */
+@JvmName("varargTest")
+fun CliktCommand.test(
+    vararg argv: String,
+    stdin: String = "",
+    envvars: Map<String, String> = emptyMap(),
+    includeSystemEnvvars: Boolean = false,
+    ansiLevel: AnsiLevel = AnsiLevel.NONE,
+    width: Int = 79,
+    height: Int = 24,
+): CliktCommandTestResult {
+    return test(argv.asList(), stdin, envvars, includeSystemEnvvars, ansiLevel, width, height)
+}
 
 /**
  * Test this command, returning a result that captures the output and result status code.


### PR DESCRIPTION
For convenience and to better visualize separate options, allow to write

    test("--foo", "--bar")

in addition to

    test("--foo --bar")

This requires to remove the `test(argv: Array<String>, ...)` overload as that would have the same JVM function signature.