### PR TITLE
Improve support for recursive lazy paraemeters

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,5 +11,5 @@ jobs:
     name: "Validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
             TEST_TASK: check
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Kotlin Native Compiler
         uses: actions/cache@v3
         with:
@@ -52,7 +52,7 @@ jobs:
     runs-on: macos-latest
     if: github.repository == 'ajalt/clikt'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Fetch git tags
         run: git fetch origin +refs/tags/*:refs/tags/*
       - name: Cache Kotlin Native Compiler

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
             TEST_TASK: check
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache Kotlin Native Compiler
         uses: actions/cache@v3
         with:

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CliktCommand.kt
@@ -62,8 +62,7 @@ abstract class CliktCommand(
     private val autoCompleteEnvvar: String? = "",
     /**
      * If true, allow multiple of this command's subcommands to be called sequentially. This will
-     * disable `allowInterspersedArgs` on the context of this command and its descendants. This
-     * functionality is experimental, and may change in a future release.
+     * disable `allowInterspersedArgs` on the context of this command and its descendants.
      */
     internal val allowMultipleSubcommands: Boolean = false,
     /**

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.cooccurring
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.provideDelegate
+import com.github.ajalt.clikt.parameters.options.defaultLazy
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/ArgumentTest.kt
@@ -51,17 +51,15 @@ class ArgumentTest {
 
     @Test
     @JsName("one_default_argument")
-    fun `one default argument`() = forAll(
-        row("", "def")
-    ) { argv, expected ->
+    fun `one default argument`() {
         class C : TestCommand() {
             val x by argument().default("def")
             override fun run_() {
-                x shouldBe expected
+                x shouldBe "def"
             }
         }
 
-        C().parse(argv)
+        C().parse("")
     }
 
     @Test

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/OptionTest.kt
@@ -456,6 +456,19 @@ class OptionTest {
     }
 
     @Test
+    @JsName("defaultLazy_option_mutual_recursion")
+    fun `defaultLazy option mutual recursion`() {
+        class C : TestCommand() {
+            val y: String by option().defaultLazy { x }
+            val x: String by option().defaultLazy { y }
+            override fun run_() {
+                y shouldBe "def"
+            }
+        }
+        shouldThrow<IllegalStateException> { C().parse("") }
+    }
+
+    @Test
     @JsName("required_option")
     fun `required option`() {
         class C : TestCommand() {

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/groups/OptionGroupsTest.kt
@@ -2,15 +2,13 @@
 
 package com.github.ajalt.clikt.parameters.groups
 
-import com.github.ajalt.clikt.core.BadParameterValue
-import com.github.ajalt.clikt.core.MissingOption
-import com.github.ajalt.clikt.core.MutuallyExclusiveGroupException
-import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.*
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.testing.TestCommand
 import com.github.ajalt.clikt.testing.formattedMessage
 import com.github.ajalt.clikt.testing.parse
+import com.github.ajalt.clikt.testing.test
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row
@@ -578,6 +576,21 @@ class OptionGroupsTest {
 
         shouldThrow<UsageError> { C(3).parse("--g=a --opt=3") }
         shouldThrow<UsageError> { C(3).parse("--opt=3") }
+    }
+
+    @Test
+    @JsName("defaultLazy_option_referencing_group")
+    fun `defaultLazy option referencing group`() {
+        class C : TestCommand() {
+            val g by Group1()
+            val o by option().int().defaultLazy { g.g11 }
+
+            override fun run_() {
+                o shouldBe 1
+            }
+        }
+
+        C().parse("--g11=1")
     }
 }
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -186,9 +186,11 @@ To implement git-style aliases:
     Committing with message: my message
     ```
 
-Note that aliases are not expanded recursively: none of the tokens that
-an alias expands to will be expanded again, even if they match another
-alias.
+!!! note
+
+    Aliases are not expanded recursively: none of the tokens that
+    an alias expands to will be expanded again, even if they match another
+    alias.
 
 You also use this functionality to implement command prefixes:
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -140,6 +140,12 @@ you can use [`defaultLazy`][defaultLazy] instead of [`default`][default]. It has
 but you give it a lambda returning the default value, and the lambda will only be called if the
 option isn't present on the command line.
 
+!!! warning
+
+    The lambda you pass to `defaultLazy` is normally called at most once. But the lambda references
+    another parameter, it may be called more than once in order to make sure the parameter it references
+    is available.
+
 ## Multi Value Options
 
 Options can take a fixed number of values separated by whitespace, a variable number of values separated by a delimiter,
@@ -1178,9 +1184,11 @@ options:
     Hello, Foo!
     ```
 
-Note that inferred names will always have a POSIX-style prefix like
-`--name`. If you want to use a different prefix, you should specify all
-option names manually.
+!!! note
+
+    Inferred names will always have a POSIX-style prefix like
+    `--name`. If you want to use a different prefix, you should specify all
+    option names manually.
 
 ## Option Transformation Order
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: "Clikt: Multiplatform command line parser for Kotlin"
 site_author: AJ Alt
 remote_branch: gh-pages
 
-copyright: 'Copyright &copy; 2022 AJ Alt'
+copyright: 'Copyright &copy; 2018 AJ Alt'
 
 theme:
   name: 'material'


### PR DESCRIPTION
Allow lazy options and arguments to reference parameters from groups, and allow unlimited recursion.

The way we support parameters referencing other parameters is by collecting any parameters that
failed to finalize and finalizing them again after all other parameters have succeeded.

Prior to this PR, we finalized options, groups, and arguments in separate passes. These passes were
interleaved and carefully ordered to work correctly.

This PR does away with the manual pass ordering and instead finalizes all parameters repeatedly,
iterating until a fixed point is reached.

Fixes #473 