### PR TITLE
Add limit parameter to counted options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Added
+- Added `limit` parameter to `option().counted()` to limit the number of times the option can be used. You can either clamp the value to the limit, or throw an error if the limit is exceeded. ([#483](https://github.com/ajalt/clikt/issues/483))
+
 ## 4.2.2
 ### Changed
 - Options and arguments can now reference option groups in their `defaultLazy` and other finalization blocks. They can also freely reference each other, including though chains of references. ([#473](https://github.com/ajalt/clikt/issues/473))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -146,6 +146,12 @@ interface Localization {
         "$value is not in the valid range of $min to $max."
 
     /**
+     * A counted option was given more times than its limit
+     */
+    fun countedOptionExceededLimit(count: Int, limit: Int): String =
+        "option was given $count times, but only $limit times are allowed"
+
+    /**
      * Invalid value for `choice` parameter
      *
      * @param choices non-empty list of possible choices

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -79,16 +79,19 @@ inline fun <OutT> OptionWithValues<Boolean, Boolean, Boolean>.convert(
 
 /**
  * Turn an option into a flag that counts the number of times it occurs on the command line.
+ *
+ * @param limit The maximum number of times the option can be given. (defaults to no limit)
+ * @param clamp If `true`, the counted value will be clamped to the [limit] if it is exceeded. If
+ *   `false`, an error will be shown isntead of clamping.
  */
 @JvmOverloads // TODO(5.0): remove this annotation
-fun RawOption.counted(limit: Int = 0, clamp: Boolean = true): OptionWithValues<Int, Int, Int> {
+fun RawOption.counted(limit: Int = Int.MAX_VALUE, clamp: Boolean = true): OptionWithValues<Int, Int, Int> {
     return int().transformValues(0..0) { it.lastOrNull() ?: 1 }.transformAll {
         val s = it.sum()
-        when {
-            limit > 0 && clamp -> s.coerceAtMost(limit)
-            limit in 1..<s -> fail(context.localization.countedOptionExceededLimit(s, limit))
-            else -> s
+        if (!clamp && s > limit) {
+            fail(context.localization.countedOptionExceededLimit(s, limit))
         }
+        s.coerceAtMost(limit)
     }
 }
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -445,10 +445,13 @@ line:
 You might want a flag option that counts the number of times it occurs on the command line. You can
 use [`counted`][counted] for this.
 
+You can specify a `limit` for the number of times the [`counted`][counted] option can be given,
+and either `clamp` the value or show an error if the limit is exceeded.
+
 === "Example"
     ```kotlin
     class Log : CliktCommand() {
-        val verbosity by option("-v").counted()
+        val verbosity by option("-v").counted(limit=3, clamp=true)
         override fun run() {
             echo("Verbosity level: $verbosity")
         }
@@ -460,6 +463,7 @@ use [`counted`][counted] for this.
     $ ./log -vvv
     Verbosity level: 3
     ```
+
 
 ## Feature Switch Flags
 


### PR DESCRIPTION
Fixes #483 

This PR adds a `limit` parameter to `counted()`, and a `clamp` parameter that matches the way `restrictTo()` works.