### PR TITLE
Add -v into the default version options

### DIFF
--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/EagerOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/EagerOption.kt
@@ -67,8 +67,8 @@ inline fun <T : CliktCommand> T.versionOption(
     version: String,
     /** The help message for the option */
     help: String = "Show the version and exit",
-    /** The names of this option. Defaults to --version */
-    names: Set<String> = setOf("--version"),
+    /** The names of this option. Defaults to -v or --version */
+    names: Set<String> = setOf("-v", "--version"),
     /** A block that returns the message to print. The [version] is passed as a parameter */
     crossinline message: (String) -> String = { "$commandName version $it" },
 ): T = eagerOption(names, help) { throw PrintMessage(message(version)) }

--- a/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/EagerOptionsTest.kt
+++ b/clikt/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/EagerOptionsTest.kt
@@ -124,11 +124,19 @@ class EagerOptionsTest {
             }
         }
 
-        val exception = shouldThrow<PrintMessage> {
+        shouldThrow<PrintMessage> {
             C().parse("--version")
+        }.let { e ->
+            e.formattedMessage shouldBe "prog version 1.2.3"
+            e.statusCode shouldBe 0
         }
-        exception.formattedMessage shouldBe "prog version 1.2.3"
-        exception.statusCode shouldBe 0
+
+        shouldThrow<PrintMessage> {
+            C().parse("-v")
+        }.let { e ->
+            e.formattedMessage shouldBe "prog version 1.2.3"
+            e.statusCode shouldBe 0
+        }
     }
 
     @Test


### PR DESCRIPTION
`-v` usually equals `--version` like `-h` to `--help`.