### PR TITLE
[complete][zsh] Fixing issue with compgen function not being found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added `limit` parameter to `option().counted()` to limit the number of times the option can be used. You can either clamp the value to the limit, or throw an error if the limit is exceeded. ([#483](https://github.com/ajalt/clikt/issues/483))
 - Added `Context.registerClosable` and `Context.callOnClose` to allow you to register cleanup actions that will be called when the command exits. ([#395](https://github.com/ajalt/clikt/issues/395))
 
+### Fixed
+- Make sure auto complete script works on zsh, fixing the error `complete:13: command not found: compdef` ([#499](https://github.com/ajalt/clikt/pull/499))
+
 ## 4.2.2
 ### Changed
 - Options and arguments can now reference option groups in their `defaultLazy` and other finalization blocks. They can also freely reference each other, including though chains of references. ([#473](https://github.com/ajalt/clikt/issues/473))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/BashCompletionGenerator.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/BashCompletionGenerator.kt
@@ -38,7 +38,9 @@ internal object BashCompletionGenerator {
                 if (zsh) {
                     append(
                         """
-                    |autoload bashcompinit
+                    |autoload -Uz compinit
+                    |compinit
+                    |autoload -Uz bashcompinit
                     |bashcompinit
                     |
                     |


### PR DESCRIPTION
Depending on your version of zsh, you may not have `autoload compinit` called in your `.zshrc` file, which results in the following error (tested on a macOS):

  complete:13: command not found: compdef

I found the solution here, which worked when tested: https://stackoverflow.com/a/76476988/1848826