### PR TITLE
[completion] Fixed autocomplete issue when using aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added `Context.registerClosable` and `Context.callOnClose` to allow you to register cleanup actions that will be called when the command exits. ([#395](https://github.com/ajalt/clikt/issues/395))
 
 ### Fixed
-- Fixed `unrecognized modifier 'i'` that happened on tab-completion when using sub command aliases
+- Fixed `unrecognized modifier 'i'` that happened on tab-completion when using sub command aliases ([#500](https://github.com/ajalt/clikt/pull/500))
 
 ## 4.2.2
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added `limit` parameter to `option().counted()` to limit the number of times the option can be used. You can either clamp the value to the limit, or throw an error if the limit is exceeded. ([#483](https://github.com/ajalt/clikt/issues/483))
 - Added `Context.registerClosable` and `Context.callOnClose` to allow you to register cleanup actions that will be called when the command exits. ([#395](https://github.com/ajalt/clikt/issues/395))
 
+### Fixed
+- Fixed `unrecognized modifier 'i'` that happened on tab-completion when using sub command aliases
+
 ## 4.2.2
 ### Changed
 - Options and arguments can now reference option groups in their `defaultLazy` and other finalization blocks. They can also freely reference each other, including though chains of references. ([#473](https://github.com/ajalt/clikt/issues/473))

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/BashCompletionGenerator.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/completion/BashCompletionGenerator.kt
@@ -135,7 +135,7 @@ internal object BashCompletionGenerator {
                     """
                 |      $name)
                 |        (( i = i + 1 ))
-                |        COMP_WORDS=( "${'$'}{COMP_WORDS[@]:0:i}"
+                |        COMP_WORDS=( "${'$'}{COMP_WORDS[@]:0:${'$'}{i}}"
                 """.trimMargin()
                 )
                 toks.joinTo(this, " ", prefix = " ") { "'$it'" }


### PR DESCRIPTION
Right now if we try to use tab-complete with an alias, we get the following error (reproduced on a macOS and zsh):

   unrecognized modifier `i'

Turns out the fix is quite simple, so here's the PR for it