### PR TITLE
Enable macArm64 CI testing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,12 @@ jobs:
     if: github.repository == 'ajalt/clikt'
     strategy:
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        os: [ macos-latest, macos-14, windows-latest, ubuntu-latest ]
         include:
           - os: macos-latest
             TEST_TASK: macosX64Test
+          - os: macos-14
+            TEST_TASK: macosArm64Test
           - os: windows-latest
             TEST_TASK: mingwX64Test
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,12 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ macos-latest,  windows-latest, ubuntu-latest ]
+        os: [ macos-latest, macos-14, windows-latest, ubuntu-latest ]
         include:
           - os: macos-latest
             TEST_TASK: macosX64Test
+          - os: macos-14
+            TEST_TASK: macosArm64Test
           - os: windows-latest
             TEST_TASK: mingwX64Test
           - os: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ dependencies {
 
 #### Multiplatform
 
-Clikt supports the following targets: `jvm`, `mingwX64`, `linuxX64`, `macosX64`, and `js` (for both
-Node.js and Browsers). Artifacts for macosArm64 are also published, but not tested with CI. [See the
+Clikt supports the following targets: `jvm`, `mingwX64`, `linuxX64`, `macosX64`, `macosArm64'`,
+and `js` (for both Node.js and Browsers). [See the
 docs](https://ajalt.github.io/clikt/advanced/#multiplatform-support) for more information about
 functionality supported on each target. You'll need to use Gradle 6 or newer.
 


### PR DESCRIPTION
From what I understand supporting the macArm64 platform was just waiting on having CI testing available.
Since M1-based standard runners are now available as `macos-14`, even if they still have a beta label, I thought I'd send you a small update to add them to the CI testing matrix.