### PR TITLE
Update Kotlin to 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/api/
 docs/changelog.md
 docs/index.md
 kotlin-js-store/
+.kotlin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - **Breaking Change:** `CliktCommand.main` and `CliktCommand.parse` are now extension functions rather than methods.
 - **Breaking Change:** `Context.obj` and `Context.terminal`, and `OptionTransformContext.terminal` are now extension functions rather than properties.
 - **Breaking Change:** The `RenderedSection` and `DefinitionRow` classes have moved to `AbstractHelpFormatter`.
+- Updated Kotlin to 2.0.0
 
 ### Fixed
 - Fixed excess arguments not being reported when `allowMultipleSubcommands=true` and a subcommand has excess arguments followed by another subcommand.

--- a/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/core/ContextTest.kt
+++ b/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/core/ContextTest.kt
@@ -124,7 +124,6 @@ class ContextTest {
     }
 
     @Test
-    @OptIn(ExperimentalStdlibApi::class)
     @JsName("register_closeable_multiple_subcommands")
     fun `register closeable multiple subcommands`() {
         var parentCount = 0

--- a/clikt/api/clikt.api
+++ b/clikt/api/clikt.api
@@ -1333,8 +1333,8 @@ public final class com/github/ajalt/clikt/parsers/CommandLineParser {
 	public static synthetic fun tokenize$default (Lcom/github/ajalt/clikt/parsers/CommandLineParser;Ljava/lang/String;Ljava/lang/String;Lcom/github/ajalt/clikt/output/Localization;ILjava/lang/Object;)Ljava/util/List;
 }
 
-public final class com/github/ajalt/clikt/parsers/FlatInvocations : kotlin/sequences/Sequence {
-	public final fun close ()V
+public final class com/github/ajalt/clikt/parsers/FlatInvocations : java/lang/AutoCloseable, kotlin/sequences/Sequence {
+	public fun close ()V
 	public fun iterator ()Ljava/util/Iterator;
 }
 

--- a/clikt/build.gradle.kts
+++ b/clikt/build.gradle.kts
@@ -46,8 +46,8 @@ kotlin {
 // https://youtrack.jetbrains.com/issue/KT-63014
 // https://github.com/Kotlin/kotlin-wasm-examples/blob/1b007347bf9f8a1ec3d420d30de1815768d5df02/nodejs-example/build.gradle.kts#L22
 rootProject.the<NodeJsRootExtension>().apply {
-    nodeVersion = "22.0.0-nightly202404032241e8c5b3"
-    nodeDownloadBaseUrl = "https://nodejs.org/download/nightly"
+    version = "22.0.0-nightly202404032241e8c5b3"
+    downloadBaseUrl = "https://nodejs.org/download/nightly"
 }
 
 rootProject.tasks.withType<KotlinNpmInstallTask>().configureEach {

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
@@ -427,7 +427,6 @@ class Context private constructor(
  * @return the closeable that was registered
  * @see Context.callOnClose
  */
-@ExperimentalStdlibApi
 fun <T : AutoCloseable> Context.registerCloseable(closeable: T): T {
     callOnClose { closeable.close() }
     return closeable

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/CommandLineParser.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/CommandLineParser.kt
@@ -87,13 +87,10 @@ object CommandLineParser {
         rootInvocation: CommandInvocation<T>,
         runCommand: (T) -> Unit,
     ) {
-        val invocations = rootInvocation.flatten()
-        try {
+        rootInvocation.flatten().use { invocations ->
             for (invocation in invocations) {
                 runCommand(invocation.command)
             }
-        } finally {
-            invocations.close()
         }
     }
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -489,7 +489,7 @@ soon as one of them returns a non-zero status code, you could implement it like 
     abstract class StatusCliktCommand : BaseCliktCommand<StatusCliktCommand>() {
         abstract fun run(): Int
     }
-    
+
     class ParentCommand : StatusCliktCommand() {
         override val allowMultipleSubcommands: Boolean = true
         override fun run(): Int {
@@ -497,37 +497,39 @@ soon as one of them returns a non-zero status code, you could implement it like 
             return 0
         }
     }
-    
+
     class SuccessCommand : StatusCliktCommand() {
         override fun run(): Int {
             echo("Success")
             return 0
         }
     }
-    
+
     class FailureCommand : StatusCliktCommand() {
         override fun run(): Int {
             echo("Failure")
             return 1001
         }
     }
-    
+
     fun StatusCliktCommand.parse(argv: Array<String>): Int {
         val parseResult = CommandLineParser.parse(this, argv.asList())
-        for (invocation in parseResult.invocation.flatten()) {
-            val status = invocation.command.run()
-            if (status != 0) {
-                return status
+        parseResult.invocation.flatten().use { invocations ->
+            for (invocation in invocations) {
+                val status = invocation.command.run()
+                if (status != 0) {
+                    return status
+                }
             }
         }
         return 0
     }
-    
+
     fun StatusCliktCommand.main(argv: Array<String>) {
         val status = CommandLineParser.mainReturningValue(this) { parse(argv) }
-        CliktUtil.exitProcess(status)
+        exitProcess(status)
     }
-    
+
     fun main(argv: Array<String>) {
         ParentCommand().subcommands(SuccessCommand(), FailureCommand()).main(argv)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.9.23"
-coroutines = "1.8.0"
+kotlin = "2.0.0"
+coroutines = "1.8.1"
 
 [libraries]
 mordant = "com.github.ajalt.mordant:mordant:2.6.0"


### PR DESCRIPTION
Since Clikt uses a lot on lambdas, compiling with `invokedynamic` reduces the jvm jar size by ~20%