### PR TITLE
Add argumentQuoteCharacterPairs command option

### DIFF
--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/BaseCliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/BaseCliktCommand.kt
@@ -92,6 +92,13 @@ abstract class BaseCliktCommand<T : BaseCliktCommand<T>>(
     open val treatUnknownOptionsAsArgs: Boolean = false
 
     /**
+     * Command-line arguments with first and last characters matching one of these pairs will
+     * always be interpreted as an argument, even if matching an option. The first and last
+     * characters will be removed in the final argument. Use to pass arguments beginning with '-'
+     */
+    open val argumentQuoteCharacterPairs: List<Pair<Char, Char>> = emptyList()
+
+    /**
      * If true, don't display this command in help output when used as a subcommand.
      */
     open val hiddenFromHelp: Boolean = false

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/ParserInternals.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/ParserInternals.kt
@@ -94,6 +94,18 @@ private class CommandParser<T : BaseCliktCommand<T>>(
             val tok = tokens[i]
             val normTok = context.tokenTransformer(context, tok)
             val prefix = splitOptionPrefix(tok).first
+
+            val quote_pair_matches = command.argumentQuoteCharacterPairs.any { pair ->
+                tok.startsWith(pair.first) && tok.endsWith(pair.second)
+            }
+
+            if (quote_pair_matches) {
+                if (!context.allowInterspersedArgs) canParseOptions = false
+                argumentTokens += tok.substring(1, tok.length - 1) // arguments aren't transformed
+                i += 1
+                continue
+            }
+
             when {
                 canExpandAtFiles
                         && tok.startsWith("@")
@@ -105,6 +117,7 @@ private class CommandParser<T : BaseCliktCommand<T>>(
                         insertTokens(loadArgFile(normTok.drop(1), context))
                     }
                 }
+
 
                 canParseOptions
                         && tok == "--" -> {

--- a/docs/options.md
+++ b/docs/options.md
@@ -263,7 +263,7 @@ You can create options that take zero or one values with [`optionalValue`][optio
 
 ### Options With a Variable Number of Values
 
-If you want your option to take a variable number of values, but want to split the value on whitespace 
+If you want your option to take a variable number of values, but want to split the value on whitespace
 [rather than a delimiter](#splitting-an-option-value-on-a-delimiter), you can use
 [`varargValues`][varargValues].
 
@@ -731,7 +731,7 @@ this by passing `acceptsValueWithoutName=true` to `int()` or `long()`.
     class Tool : CliktCommand() {
         val level by option("-l", "--level", metavar = "<number>")
             .int(acceptsValueWithoutName = true)
-    
+
         override fun run() {
             echo("Level: $level")
         }
@@ -754,7 +754,7 @@ this by passing `acceptsValueWithoutName=true` to `int()` or `long()`.
     ```text
     $ ./tool --help
     Usage: tool [<options>]
-    
+
     Options:
     -<number>, -l, --level <number>
     -h, --help             Show this message and exit
@@ -994,6 +994,47 @@ You'll often want to set [`allowInterspersedArgs = false`][allowInterspersedArgs
 when using `treatUnknownOptionsAsArgs`. You may also find that subcommands are a better fit than
 `treatUnknownOptionsAsArgs` for your use case.
 
+## Passing arguments matching options
+
+To explicitly pass strings beginning with '-' as arguments instead of them being interpreted as options, add a quote character pair to `argumentQuoteCharacterPairs`. If an input begins and ends with a pair's characters, it will be used as an argument with the quote characters removed.
+
+=== "Example"
+    ```kotlin
+    class Echo : CliktCommand() {
+        override val argumentQuoteCharacterPairs = listOf(Pair('"', '"'))
+
+        val disable by option(help = "Disable").flag()
+        val argument by argument().optional()
+
+        override fun run() {
+            if (disable) {
+                echo("Disabled")
+                return
+            }
+
+            echo(argument)
+        }
+    }
+    ```
+
+=== "Usage 1"
+    ```text
+    $ ./echo --disable
+    Disabled
+    ```
+
+=== "Usage 2"
+    ```text
+    $ ./echo "--disable" # Most shells will remove quotes, so they must be escaped
+    Disabled
+    ```
+
+=== "Usage 3"
+    ```text
+    $ ./echo \"--disable\"
+    --disable
+    ```
+
 ## Values From Environment Variables
 
 Clikt supports reading option values from environment variables if they
@@ -1201,7 +1242,7 @@ options:
 Clikt has a large number of extension functions that can modify options. When applying multiple
 functions to the same option, there's only one valid order for the functions to be applied. For
 example, `option().default(3).int()` will not compile, because [`default`][default] must be applied
-after the value type conversion. 
+after the value type conversion.
 
 You can call [`convert`][convert] multiple times, but you can only apply one transform of each other
 type. So `option().default("").multiple()` is invalid, since [`default`][default] and


### PR DESCRIPTION
Adds the `argumentQuoteCharacterPairs` command option, which is a list of character pairs. 

If an argument's first and last characters match one of these pairs, it will always be interpreted as an argument rather than checking if it matches an option. The list is empty by default to prevent breaking existing functionality.

This is allows applications to receive string arguments beginning with `-`, such as YouTube video IDs in my case.