### PR TITLE
feat: move NoOpCliktCommand from clikt-mordant to clikt module

### DIFF
--- a/clikt-mordant/api/clikt-mordant.api
+++ b/clikt-mordant/api/clikt-mordant.api
@@ -43,13 +43,6 @@ public final class com/github/ajalt/clikt/core/MordantContextKt {
 	public static final fun setTerminal (Lcom/github/ajalt/clikt/core/Context$Builder;Lcom/github/ajalt/mordant/terminal/Terminal;)V
 }
 
-public class com/github/ajalt/clikt/core/NoOpCliktCommand : com/github/ajalt/clikt/core/CliktCommand {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun run ()V
-}
-
 public class com/github/ajalt/clikt/output/MordantHelpFormatter : com/github/ajalt/clikt/output/AbstractHelpFormatter {
 	public fun <init> (Lcom/github/ajalt/clikt/core/Context;Ljava/lang/String;ZZ)V
 	public synthetic fun <init> (Lcom/github/ajalt/clikt/core/Context;Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/clikt/api/clikt.api
+++ b/clikt/api/clikt.api
@@ -374,6 +374,13 @@ public final class com/github/ajalt/clikt/core/MutuallyExclusiveGroupException :
 	public final fun getNames ()Ljava/util/List;
 }
 
+public class com/github/ajalt/clikt/core/NoOpCliktCommand : com/github/ajalt/clikt/core/CoreCliktCommand {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun run ()V
+}
+
 public final class com/github/ajalt/clikt/core/NoSuchArgument : com/github/ajalt/clikt/core/UsageError {
 	public fun <init> (Ljava/util/List;)V
 	public fun formatMessage (Lcom/github/ajalt/clikt/output/Localization;Lcom/github/ajalt/clikt/output/ParameterFormatter;)Ljava/lang/String;

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/NoOpCliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/NoOpCliktCommand.kt
@@ -1,7 +1,7 @@
 package com.github.ajalt.clikt.core
 
 /**
- * A [CliktCommand] that has a default implementation of [CliktCommand.run] that is a no-op.
+ * A [CoreCliktCommand] that has a default implementation of [CoreCliktCommand.run] that is a no-op.
  */
 open class NoOpCliktCommand(
     /**
@@ -9,6 +9,6 @@ open class NoOpCliktCommand(
      * class name.
      */
     name: String? = null,
-) : CliktCommand(name) {
+) : CoreCliktCommand(name) {
     final override fun run() {}
 }


### PR DESCRIPTION
**Move `NoOpCliktCommand` class from `clikt-mordant` to `clikt` module to allow use it for both**

I'm uncertain if there is a reason why this class is in the `clikt-mordant` module though it seems that the class `NoOpCliktCommand` does not use any Mordant-specific implementation, moving it to the `clikt` module to allow the use of it when using `clikt-core` without a **breaking change**. This should work for both `clikt` and `clikt-mordant`.

We might need to update the docs in case something got outdated, or if there is not, we might want to consider documenting this change.