### PR TITLE
update name of shell completion docs section

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,7 +145,7 @@ nav:
       - 'Launching Editors': utilities.md
       - 'Input Prompts': utilities/#input-prompts
       - 'Confirmation Prompts': utilities/#confirmation-prompts
-  - 'Bash Autocomplete':
+  - 'Shell Completion':
       - 'Supported Functionality': autocomplete.md
       - 'Enabling Completion': autocomplete/#enabling-completion
       - 'Customizing Completions': autocomplete/#customizing-completions


### PR DESCRIPTION
I was sad for a few seconds that is supports only bash, until I read more :)