### PR TITLE
Add CoreNoOpCliktCommand

### DIFF
--- a/clikt-mordant/api/clikt-mordant.api
+++ b/clikt-mordant/api/clikt-mordant.api
@@ -43,6 +43,13 @@ public final class com/github/ajalt/clikt/core/MordantContextKt {
 	public static final fun setTerminal (Lcom/github/ajalt/clikt/core/Context$Builder;Lcom/github/ajalt/mordant/terminal/Terminal;)V
 }
 
+public class com/github/ajalt/clikt/core/NoOpCliktCommand : com/github/ajalt/clikt/core/CliktCommand {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun run ()V
+}
+
 public class com/github/ajalt/clikt/output/MordantHelpFormatter : com/github/ajalt/clikt/output/AbstractHelpFormatter {
 	public fun <init> (Lcom/github/ajalt/clikt/core/Context;Ljava/lang/String;ZZ)V
 	public synthetic fun <init> (Lcom/github/ajalt/clikt/core/Context;Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/clikt-mordant/src/commonMain/kotlin/com/github/ajalt/clikt/core/NoOpCliktCommand.kt
+++ b/clikt-mordant/src/commonMain/kotlin/com/github/ajalt/clikt/core/NoOpCliktCommand.kt
@@ -1,7 +1,7 @@
 package com.github.ajalt.clikt.core
 
 /**
- * A [CoreCliktCommand] that has a default implementation of [CoreCliktCommand.run] that is a no-op.
+ * A [CoreCliktCommand] that has a default implementation of [CliktCommand.run] that is a no-op.
  */
 open class NoOpCliktCommand(
     /**
@@ -9,6 +9,6 @@ open class NoOpCliktCommand(
      * class name.
      */
     name: String? = null,
-) : CoreCliktCommand(name) {
+) : CliktCommand(name) {
     final override fun run() {}
 }

--- a/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
+++ b/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/core/CliktCommandTest.kt
@@ -34,7 +34,7 @@ class CliktCommandTest {
         class ListAllValuesCommand : TestCommand()
         class LGTMMeansLookingGoodToMe : TestCommand()
         class `nothing-to-change` : TestCommand()
-        class ListCommands : NoOpCliktCommand()
+        class ListCommands : CoreNoOpCliktCommand()
         ListAllValuesCommand().commandName shouldBe "list-all-values"
         LGTMMeansLookingGoodToMe().commandName shouldBe "lgtmmeans-looking-good-to-me"
         `nothing-to-change`().commandName shouldBe "nothing-to-change"

--- a/clikt/api/clikt.api
+++ b/clikt/api/clikt.api
@@ -307,6 +307,13 @@ public final class com/github/ajalt/clikt/core/CoreCliktCommandKt {
 	public static final fun parse (Lcom/github/ajalt/clikt/core/CoreCliktCommand;[Ljava/lang/String;)V
 }
 
+public class com/github/ajalt/clikt/core/CoreNoOpCliktCommand : com/github/ajalt/clikt/core/CoreCliktCommand {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun run ()V
+}
+
 public final class com/github/ajalt/clikt/core/FileNotFound : com/github/ajalt/clikt/core/UsageError {
 	public fun <init> (Ljava/lang/String;)V
 	public fun formatMessage (Lcom/github/ajalt/clikt/output/Localization;Lcom/github/ajalt/clikt/output/ParameterFormatter;)Ljava/lang/String;
@@ -372,13 +379,6 @@ public final class com/github/ajalt/clikt/core/MutuallyExclusiveGroupException :
 	public fun <init> (Ljava/util/List;)V
 	public fun formatMessage (Lcom/github/ajalt/clikt/output/Localization;Lcom/github/ajalt/clikt/output/ParameterFormatter;)Ljava/lang/String;
 	public final fun getNames ()Ljava/util/List;
-}
-
-public class com/github/ajalt/clikt/core/NoOpCliktCommand : com/github/ajalt/clikt/core/CoreCliktCommand {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun run ()V
 }
 
 public final class com/github/ajalt/clikt/core/NoSuchArgument : com/github/ajalt/clikt/core/UsageError {

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CoreNoOpCliktCommand.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/CoreNoOpCliktCommand.kt
@@ -1,0 +1,14 @@
+package com.github.ajalt.clikt.core
+
+/**
+ * A [CoreCliktCommand] that has a default implementation of [CoreCliktCommand.run] that is a no-op.
+ */
+open class CoreNoOpCliktCommand(
+    /**
+     * The name of the program to use in the help output. If not given, it is inferred from the
+     * class name.
+     */
+    name: String? = null,
+) : CoreCliktCommand(name) {
+    final override fun run() {}
+}

--- a/samples/aliases/src/main/kotlin/com/github/ajalt/clikt/samples/aliases/main.kt
+++ b/samples/aliases/src/main/kotlin/com/github/ajalt/clikt/samples/aliases/main.kt
@@ -10,7 +10,7 @@ import java.io.File
  * @param configFile A config file containing aliases, one per line, in the form `token = alias`. Aliases can
  *   have multiple tokens (e.g. `cm = commit -m`).
  */
-class AliasedCli(private val configFile: File) : NoOpCliktCommand() {
+class AliasedCli(private val configFile: File) : CoreNoOpCliktCommand() {
     override fun help(context: Context) = "An example that supports aliased subcommands"
     override fun aliases(): Map<String, List<String>> {
         return configFile.readLines().map { it.split("=", limit = 2) }


### PR DESCRIPTION
#526 Made the `NoOpCliktCommand` available in `core`, and this PR follows up by renaming it to match the other core commands and making a separate command that uses mordant.

While it is a bit annoying to need separate copies of all the commands just to install mordant, I don't know of a better solution that works an all multiplatform targets.