### PR TITLE
Don't print help on empty args when envvars are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### Fixed
 - Fixed excess arguments not being reported when `allowMultipleSubcommands=true` and a subcommand has excess arguments followed by another subcommand.
+- Commands with `printHelpOnEmptyArgs=true` will no longer print help if an option has a value from an environment variable or value source.  ([#382](https://github.com/ajalt/clikt/pull/382))
 
 ### Deprecated
 - Deprecated `Context.originalArgv`. It will now always return an empty list. If your commands need an argv, you can pass it to them before you run them, or set in on the new `Context.data` map.

--- a/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/EnvvarOptionsTest.kt
+++ b/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/EnvvarOptionsTest.kt
@@ -1,16 +1,16 @@
 package com.github.ajalt.clikt.parameters
 
-import com.github.ajalt.clikt.core.*
+import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.core.MutuallyExclusiveGroupException
+import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.cooccurring
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.single
 import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.int
-import com.github.ajalt.clikt.testing.TestCommand
-import com.github.ajalt.clikt.testing.TestSource
-import com.github.ajalt.clikt.testing.defaultLocalization
-import com.github.ajalt.clikt.testing.parse
+import com.github.ajalt.clikt.testing.*
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row
@@ -19,10 +19,6 @@ import kotlin.js.JsName
 import kotlin.test.Test
 
 class EnvvarOptionsTest {
-    private fun <T : CliktCommand> T.withEnv(vararg entries: Pair<String, String?>): T {
-        return context { readEnvvar = { entries.toMap()[it] } }
-    }
-
     @Test
     @JsName("explicit_envvar")
     fun `explicit envvar`() {

--- a/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/testing/utils.kt
+++ b/clikt-mordant/src/commonTest/kotlin/com/github/ajalt/clikt/testing/utils.kt
@@ -1,6 +1,8 @@
 package com.github.ajalt.clikt.testing
 
+import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.UsageError
+import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.output.Localization
 import com.github.ajalt.clikt.output.ParameterFormatter
 
@@ -11,3 +13,7 @@ val Throwable.formattedMessage: String?
     ) ?: message
 
 internal val defaultLocalization = object : Localization {}
+
+internal fun <T : CliktCommand> T.withEnv(vararg entries: Pair<String, String?>): T {
+    return context { readEnvvar = { entries.toMap()[it] } }
+}

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/ParserInternals.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parsers/ParserInternals.kt
@@ -2,6 +2,7 @@ package com.github.ajalt.clikt.parsers
 
 import com.github.ajalt.clikt.core.*
 import com.github.ajalt.clikt.parameters.options.Option
+import com.github.ajalt.clikt.parameters.options.hasEnvvarOrSourcedValue
 import com.github.ajalt.clikt.parameters.options.splitOptionPrefix
 
 internal fun <T : BaseCliktCommand<T>> parseArgv(
@@ -149,7 +150,9 @@ private class CommandParser<T : BaseCliktCommand<T>>(
     }
 
     private fun printHelpOnEmptyArgsIfNecessary(): Boolean {
-        if (i > tokens.lastIndex && command.printHelpOnEmptyArgs) {
+        if (i > tokens.lastIndex && command.printHelpOnEmptyArgs
+            && command._options.none { it.hasEnvvarOrSourcedValue(context, emptyList()) }
+        ) {
             errors += PrintHelpMessage(context, error = true)
             return true
         }


### PR DESCRIPTION
Fixes #382 