### PR TITLE
Bump kotlin 2.1.0, binary-compatibility-validator 0.16.3

### DIFF
--- a/clikt-mordant-markdown/build.gradle.kts
+++ b/clikt-mordant-markdown/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
-
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")

--- a/clikt-mordant/build.gradle.kts
+++ b/clikt-mordant/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
-
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")

--- a/clikt/build.gradle.kts
+++ b/clikt/build.gradle.kts
@@ -1,8 +1,7 @@
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
-
 
 plugins {
     kotlin("multiplatform")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.0"
+kotlin = "2.1.0"
 coroutines = "1.8.1"
 mordant = "3.0.0"
 
@@ -21,4 +21,4 @@ kotlinx-serialization = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2"
 [plugins]
 dokka = "org.jetbrains.dokka:1.9.20"
 publish = "com.vanniktech.maven.publish:0.28.0"
-kotlinBinaryCompatibilityValidator = "org.jetbrains.kotlinx.binary-compatibility-validator:0.14.0"
+kotlinBinaryCompatibilityValidator = "org.jetbrains.kotlinx.binary-compatibility-validator:0.16.3"

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -1,6 +1,4 @@
-import org.jetbrains.dokka.gradle.DokkaTaskPartial
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
-
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
     kotlin("multiplatform")


### PR DESCRIPTION
- closes #566 

tests passed

<img width="1354" alt="Screenshot 2024-11-27 at 18 28 36" src="https://github.com/user-attachments/assets/c231f030-4afb-4e71-b568-b43bb8382408">



added `test.api` file due to
<img width="1187" alt="Screenshot 2024-11-27 at 18 30 29" src="https://github.com/user-attachments/assets/9bed3ce8-f2e5-479b-a5e1-bc958261d7d3">


