### PR TITLE
fix: do not prompt on non-interactive terminals

### DIFF
--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/testing/TestingUtilsTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/testing/TestingUtilsTest.kt
@@ -63,7 +63,7 @@ class TestingUtilsTest {
             }
         }
 
-        val result = C().test("", stdin = "foo\nbar")
+        val result = C().test("", stdin = "foo\nbar", inputInteractive = true)
         result.stdout shouldBe "O1: O2: "
         result.stderr shouldBe "err\n"
         result.output shouldBe "O1: O2: err\n"


### PR DESCRIPTION
fixes https://github.com/ajalt/clikt/issues/618

this has backwards compatibility concerns for library users' tests, as demonstrated by the need to alter this project's own existing tests. this could be considered fine as, if it is fixing incorrect behaviour, the existing test would be considered to be making incorrect assertions in the first place.