### PR TITLE
fix message for invalid uint / ulong

### DIFF
--- a/clikt/api/clikt.api
+++ b/clikt/api/clikt.api
@@ -708,6 +708,7 @@ public abstract interface class com/github/ajalt/clikt/output/Localization {
 	public abstract fun requiredMutexOption (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun stringMetavar ()Ljava/lang/String;
 	public abstract fun switchOptionEnvvar ()Ljava/lang/String;
+	public abstract fun uintConversionError (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun unclosedQuote ()Ljava/lang/String;
 	public abstract fun usageError ()Ljava/lang/String;
 	public abstract fun usageTitle ()Ljava/lang/String;
@@ -768,6 +769,7 @@ public final class com/github/ajalt/clikt/output/Localization$DefaultImpls {
 	public static fun requiredMutexOption (Lcom/github/ajalt/clikt/output/Localization;Ljava/lang/String;)Ljava/lang/String;
 	public static fun stringMetavar (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun switchOptionEnvvar (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
+	public static fun uintConversionError (Lcom/github/ajalt/clikt/output/Localization;Ljava/lang/String;)Ljava/lang/String;
 	public static fun unclosedQuote (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun usageError (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun usageTitle (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -137,6 +137,9 @@ interface Localization {
     /** Invalid value for a parameter of type [Int] or [Long] */
     fun intConversionError(value: String) = "$value is not a valid integer"
 
+    /** Invalid value for a parameter of type [UInt] or [ULong] */
+    fun uintConversionError(value: String) = "$value is not a valid unsigned integer"
+
     /** Invalid value for a parameter of type [Boolean] */
     fun boolConversionError(value: String) = "$value is not a valid boolean"
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/uint.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/uint.kt
@@ -10,7 +10,7 @@ import com.github.ajalt.clikt.parameters.transform.TransformContext
 
 
 private val conversion: TransformContext.(String) -> UInt =
-    { it.toUIntOrNull() ?: fail(context.localization.intConversionError(it)) }
+    { it.toUIntOrNull() ?: fail(context.localization.uintConversionError(it)) }
 
 /** Convert the argument values to an `UInt` */
 fun RawArgument.uint(): ProcessedArgument<UInt, UInt> = convert(conversion = conversion)

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/ulong.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/types/ulong.kt
@@ -10,7 +10,7 @@ import com.github.ajalt.clikt.parameters.transform.TransformContext
 
 
 private val conversion: TransformContext.(String) -> ULong =
-    { it.toULongOrNull() ?: fail(context.localization.intConversionError(it)) }
+    { it.toULongOrNull() ?: fail(context.localization.uintConversionError(it)) }
 
 /** Convert the argument values to a `ULong` */
 fun RawArgument.ulong(): ProcessedArgument<ULong, ULong> = convert(conversion = conversion)

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/UIntTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/UIntTest.kt
@@ -55,7 +55,7 @@ class UIntTest {
         }
 
         shouldThrow<BadParameterValue> { C().parse("--foo bar") }
-            .formattedMessage shouldBe "invalid value for --foo: bar is not a valid integer"
+            .formattedMessage shouldBe "invalid value for --foo: bar is not a valid unsigned integer"
 
         shouldThrow<NoSuchOption> { C().parse("-2") }
         shouldThrow<BadParameterValue> { C().parse("--foo=-1") }

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/ULongTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/types/ULongTest.kt
@@ -40,7 +40,7 @@ class ULongTest {
         }
 
         shouldThrow<BadParameterValue> { C().parse("--foo bar") }
-            .formattedMessage shouldBe "invalid value for --foo: bar is not a valid integer"
+            .formattedMessage shouldBe "invalid value for --foo: bar is not a valid unsigned integer"
 
         shouldThrow<NoSuchOption> { C().parse("-2") }
         shouldThrow<BadParameterValue> { C().parse("--foo=-1") }


### PR DESCRIPTION
If a negative integer value is passed for a uint / ulong option, the current error message is not very helpful.