### PR TITLE
Add Context.showEnvvarsInHelp to show envvar names in help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Added `Context.showEnvvarsInHelp` to show the names of the environment variables that options read from in the help output. You can override the name shown for an option (or hide it) with the `HelpFormatter.Tags.ENVVAR` help tag. ([#320](https://github.com/ajalt/clikt/issues/320))
 
 ## 5.1.0
 ### Added

--- a/clikt/api/clikt.api
+++ b/clikt/api/clikt.api
@@ -211,7 +211,7 @@ public final class com/github/ajalt/clikt/core/Context {
 	public static final field Companion Lcom/github/ajalt/clikt/core/Context$Companion;
 	public static final field DEFAULT_OBJ_KEY Ljava/lang/String;
 	public static final field TERMINAL_KEY Ljava/lang/String;
-	public synthetic fun <init> (Lcom/github/ajalt/clikt/core/Context;Lcom/github/ajalt/clikt/core/BaseCliktCommand;ZZLjava/lang/String;ZLjava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ZLcom/github/ajalt/clikt/sources/ValueSource;Lkotlin/jvm/functions/Function2;Lcom/github/ajalt/clikt/output/Localization;Lkotlin/jvm/functions/Function1;Ljava/util/Map;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/github/ajalt/clikt/core/Context;Lcom/github/ajalt/clikt/core/BaseCliktCommand;ZZLjava/lang/String;ZZLjava/util/Set;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ZLcom/github/ajalt/clikt/sources/ValueSource;Lkotlin/jvm/functions/Function2;Lcom/github/ajalt/clikt/output/Localization;Lkotlin/jvm/functions/Function1;Ljava/util/Map;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun callOnClose (Lkotlin/jvm/functions/Function0;)V
 	public final fun close ()V
 	public final fun commandNameWithParents ()Ljava/util/List;
@@ -240,6 +240,7 @@ public final class com/github/ajalt/clikt/core/Context {
 	public final fun getReadArgumentFile ()Lkotlin/jvm/functions/Function1;
 	public final fun getReadEnvvar ()Lkotlin/jvm/functions/Function1;
 	public final fun getReadEnvvarBeforeValueSource ()Z
+	public final fun getShowEnvvarsInHelp ()Z
 	public final fun getSuggestTypoCorrection ()Lkotlin/jvm/functions/Function2;
 	public final fun getTokenTransformer ()Lkotlin/jvm/functions/Function2;
 	public final fun getTransformToken ()Lkotlin/jvm/functions/Function2;
@@ -270,6 +271,7 @@ public final class com/github/ajalt/clikt/core/Context$Builder {
 	public final fun getReadArgumentFile ()Lkotlin/jvm/functions/Function1;
 	public final fun getReadEnvvar ()Lkotlin/jvm/functions/Function1;
 	public final fun getReadEnvvarBeforeValueSource ()Z
+	public final fun getShowEnvvarsInHelp ()Z
 	public final fun getSuggestTypoCorrection ()Lkotlin/jvm/functions/Function2;
 	public final fun getTokenTransformer ()Lkotlin/jvm/functions/Function2;
 	public final fun getTransformToken ()Lkotlin/jvm/functions/Function2;
@@ -290,6 +292,7 @@ public final class com/github/ajalt/clikt/core/Context$Builder {
 	public final fun setReadArgumentFile (Lkotlin/jvm/functions/Function1;)V
 	public final fun setReadEnvvar (Lkotlin/jvm/functions/Function1;)V
 	public final fun setReadEnvvarBeforeValueSource (Z)V
+	public final fun setShowEnvvarsInHelp (Z)V
 	public final fun setSuggestTypoCorrection (Lkotlin/jvm/functions/Function2;)V
 	public final fun setTokenTransformer (Lkotlin/jvm/functions/Function2;)V
 	public final fun setTransformToken (Lkotlin/jvm/functions/Function2;)V
@@ -650,6 +653,7 @@ public final class com/github/ajalt/clikt/output/HelpFormatter$ParameterHelp$Sub
 
 public final class com/github/ajalt/clikt/output/HelpFormatter$Tags {
 	public static final field DEFAULT Ljava/lang/String;
+	public static final field ENVVAR Ljava/lang/String;
 	public static final field INSTANCE Lcom/github/ajalt/clikt/output/HelpFormatter$Tags;
 	public static final field REQUIRED Ljava/lang/String;
 }
@@ -675,6 +679,7 @@ public abstract interface class com/github/ajalt/clikt/output/Localization {
 	public fun floatMetavar ()Ljava/lang/String;
 	public fun helpOptionMessage ()Ljava/lang/String;
 	public fun helpTagDefault ()Ljava/lang/String;
+	public fun helpTagEnvvar ()Ljava/lang/String;
 	public fun helpTagRequired ()Ljava/lang/String;
 	public fun incorrectArgumentValueCount (Ljava/lang/String;I)Ljava/lang/String;
 	public fun incorrectOptionValueCount (Ljava/lang/String;I)Ljava/lang/String;
@@ -736,6 +741,7 @@ public final class com/github/ajalt/clikt/output/Localization$DefaultImpls {
 	public static fun floatMetavar (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun helpOptionMessage (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun helpTagDefault (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
+	public static fun helpTagEnvvar (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun helpTagRequired (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun incorrectArgumentValueCount (Lcom/github/ajalt/clikt/output/Localization;Ljava/lang/String;I)Ljava/lang/String;
 	public static fun incorrectOptionValueCount (Lcom/github/ajalt/clikt/output/Localization;Ljava/lang/String;I)Ljava/lang/String;

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/core/Context.kt
@@ -40,6 +40,11 @@ class Context private constructor(
      */
     val autoEnvvarPrefix: String?,
     /**
+     * If true, the help output for options will include the name of the environment variable
+     * that the option reads when it isn't given on the command line.
+     */
+    val showEnvvarsInHelp: Boolean,
+    /**
      * Set this to false to prevent extra messages from being printed automatically.
      * You can still access them at [messages][BaseCliktCommand.messages] inside of
      * `CliktCommand.run`.
@@ -301,6 +306,17 @@ class Context private constructor(
         }
 
         /**
+         * If true, the help output for options will include the name of the environment variable
+         * that the option reads when it isn't given on the command line (either its `envvar`, or
+         * the name inferred from [autoEnvvarPrefix]).
+         *
+         * You can override this for individual options by setting a value for the
+         * [HelpFormatter.Tags.ENVVAR] key in their `helpTags`: set it to the name to show, or to
+         * an empty string to hide the name for that option.
+         */
+        var showEnvvarsInHelp: Boolean = parent?.showEnvvarsInHelp ?: false
+
+        /**
          * If true, arguments starting with `@` will be expanded as argument files. If false, they
          * will be treated as normal arguments.
          */
@@ -436,6 +452,7 @@ class Context private constructor(
                     allowInterspersedArgs = interspersed,
                     allowGroupedShortOptions = allowGroupedShortOptions,
                     autoEnvvarPrefix = autoEnvvarPrefix,
+                    showEnvvarsInHelp = showEnvvarsInHelp,
                     printExtraMessages = printExtraMessages,
                     helpOptionNames = helpOptionNames.toSet(),
                     helpFormatter = helpFormatter ?: { PlaintextHelpFormatter(it) },

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/AbstractHelpFormatter.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/AbstractHelpFormatter.kt
@@ -184,6 +184,7 @@ abstract class AbstractHelpFormatter<PartT>(
         return when (tag) {
             HelpFormatter.Tags.DEFAULT -> showDefaultValues && value.isNotBlank()
             HelpFormatter.Tags.REQUIRED -> showRequiredTag
+            HelpFormatter.Tags.ENVVAR -> value.isNotBlank()
             else -> true
         }
     }
@@ -197,6 +198,7 @@ abstract class AbstractHelpFormatter<PartT>(
         val t = when (tag) {
             HelpFormatter.Tags.DEFAULT -> localization.helpTagDefault()
             HelpFormatter.Tags.REQUIRED -> localization.helpTagRequired()
+            HelpFormatter.Tags.ENVVAR -> localization.helpTagEnvvar()
             else -> tag
         }
         val fullTag = if (value.isBlank()) "($t)" else "($t: $value)"

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/HelpFormatter.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/HelpFormatter.kt
@@ -88,6 +88,12 @@ interface HelpFormatter {
 
         /** If true, this option is required. Only used for help output. */
         const val REQUIRED = "required"
+
+        /**
+         * The name of the environment variable that will be used for this option's value if it
+         * isn't given on the command line, or blank if the name should never be shown.
+         */
+        const val ENVVAR = "envvar"
     }
 }
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -242,6 +242,9 @@ interface Localization {
     /** Text rendered for parameters tagged with [HelpFormatter.Tags.REQUIRED] */
     fun helpTagRequired(): String = "required"
 
+    /** Text rendered for parameters tagged with [HelpFormatter.Tags.ENVVAR] */
+    fun helpTagEnvvar(): String = "env var"
+
     /** The default message for the `--help` option. */
     fun helpOptionMessage(): String = "Show this message and exit"
 }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Option.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/Option.kt
@@ -63,7 +63,7 @@ interface Option {
             metavar(context),
             optionHelp(context),
             nvalues,
-            helpTags,
+            helpTags + envvarHelpTags(context),
             acceptsNumberValueWithoutName,
             acceptsUnattachedValue,
             groupName = (this as? StaticallyGroupedOption)?.groupName
@@ -119,6 +119,20 @@ internal fun inferOptionNames(names: Set<String>, propertyName: String): Set<Str
         "${it.value[0]}-${it.value[1]}"
     }.lowercase()
     return setOf(normalizedName)
+}
+
+/**
+ * If [Context.showEnvvarsInHelp] is set, return a [HelpFormatter.Tags.ENVVAR] tag with the name of
+ * the envvar that this option reads its value from, if it has one.
+ */
+private fun Option.envvarHelpTags(context: Context): Map<String, String> {
+    if (!context.showEnvvarsInHelp) return emptyMap()
+    // An explicit tag takes precedence over the inferred name
+    if (HelpFormatter.Tags.ENVVAR in helpTags) return emptyMap()
+    // Eager options and options without values never read from envvars
+    if (eager || this !is OptionWithValues<*, *, *>) return emptyMap()
+    val name = inferEnvvar(names, envvar, context.autoEnvvarPrefix) ?: return emptyMap()
+    return mapOf(HelpFormatter.Tags.ENVVAR to name)
 }
 
 internal fun inferEnvvar(names: Set<String>, envvar: String?, autoEnvvarPrefix: String?): String? {

--- a/docs/documenting.md
+++ b/docs/documenting.md
@@ -393,6 +393,51 @@ You can also show a tag for required options by passing `showRequiredTag = true`
       -h, --help         Show this message and exit
     ```
 
+## Environment Variables in Help
+
+If your options read values from [environment variables][envvars], you can show the envvar names in
+the help output by setting [`showEnvvarsInHelp`][showEnvvarsInHelp]` = true` on a command's
+context. Both explicit `envvar` names and names inferred from `autoEnvvarPrefix` are shown. Since
+the setting is on the context, it's propagated to subcommands.
+
+=== "Example"
+    ```kotlin
+    class Tool : NoOpCliktCommand() {
+        init {
+            context {
+                autoEnvvarPrefix = "TOOL"
+                showEnvvarsInHelp = true
+            }
+        }
+
+        val explicit by option(help = "explicit envvar name", envvar = "MY_OPTION")
+        val inferred by option(help = "inferred envvar name")
+    }
+    ```
+
+=== "Usage"
+    ```text
+    $ ./tool --help
+    Usage: tool [<options>]
+
+    Options:
+      --explicit=<text>  explicit envvar name (env var: MY_OPTION)
+      --inferred=<text>  inferred envvar name (env var: TOOL_INFERRED)
+      -h, --help         Show this message and exit
+    ```
+
+You can override the name shown for a single option by setting a value for the
+[`HelpFormatter.Tags.ENVVAR`][Tags] key in its `helpTags`. Set it to an empty string to hide the
+envvar name for that option, or to a non-empty string to show that name even when
+`showEnvvarsInHelp` is false.
+
+```kotlin
+val secret by option(
+    envvar = "TOOL_SECRET",
+    helpTags = mapOf(HelpFormatter.Tags.ENVVAR to ""),
+)
+```
+
 ## Grouping Options in Help
 
 You can group options into separate help sections by using [OptionGroup][OptionGroup]
@@ -507,10 +552,13 @@ You can localize error messages by implementing [`Localization`][Localization] a
 [Localization]:             api/clikt/com.github.ajalt.clikt.output/-localization/index.html
 [OptionGroup]:              api/clikt/com.github.ajalt.clikt.parameters.groups/-option-group/index.html
 [PrintHelpMessage]:         api/clikt/com.github.ajalt.clikt.core/-print-help-message/index.html
+[Tags]:                     api/clikt/com.github.ajalt.clikt.output/-help-formatter/-tags/index.html
 [customizing-command-name]: commands.md#customizing-command-name
 [customizing-contexts]:     commands.md#customizing-contexts
 [default]:                  api/clikt/com.github.ajalt.clikt.parameters.options/default.html
 [eager-options]:            options.md#eager-options
+[envvars]:                  options.md#values-from-environment-variables
+[showEnvvarsInHelp]:        api/clikt/com.github.ajalt.clikt.core/-context/-builder/show-envvars-in-help.html
 [groups.provideDelegate]:   api/clikt/com.github.ajalt.clikt.parameters.groups/provide-delegate.html
 [nel]:                      https://www.fileformat.info/info/unicode/char/0085/index.htm
 [provideDelegate]:          api/clikt/com.github.ajalt.clikt.parameters.groups/provide-delegate.html

--- a/docs/options.md
+++ b/docs/options.md
@@ -1061,6 +1061,12 @@ prefix is `MY_TOOL`, the option's envvar name will be `MY_TOOL_FOO_BAR`.
     Hello Foo
     ```
 
+### Environment Variables in Help Output
+
+Envvar names aren't shown in the help output by default. You can enable that by setting
+`showEnvvarsInHelp = true` on a command's context. See
+[the documentation on help output](documenting.md#environment-variables-in-help) for details.
+
 ### Multiple Values from Environment Variables
 
 You might need to allow users to specify multiple values for an option in a single environment

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/MordantHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/MordantHelpFormatterTest.kt
@@ -16,6 +16,7 @@ import com.github.ajalt.mordant.terminal.Terminal
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.js.JsName
 import kotlin.test.Test
@@ -601,6 +602,121 @@ class MordantHelpFormatterTest {
             |  -b, --bb=<text>  bb option help (default: 123)
             """
         )
+    }
+
+    @[Test JsName("envvar_option_tag")]
+    fun `envvar option tag`() {
+        c.registerOption(c.option("--aa", "-a", help = "aa option help"))
+        c.registerOption(c.option("--bb", "-b", help = "bb option help", envvar = "BB"))
+        c.context { showEnvvarsInHelp = true }
+        doTest(
+            """
+            |Usage: prog [<options>]
+            |
+            |Options:
+            |  -a, --aa=<text>  aa option help
+            |  -b, --bb=<text>  bb option help (env var: BB)
+            """
+        )
+    }
+
+    @[Test JsName("envvar_option_tag_with_auto_envvar_prefix")]
+    fun `envvar option tag with auto envvar prefix`() {
+        c.registerOption(c.option("--aa", "-a", help = "aa option help"))
+        c.registerOption(c.option("--bb", "-b", help = "bb option help", envvar = "BB"))
+        c.context {
+            autoEnvvarPrefix = "PROG"
+            showEnvvarsInHelp = true
+        }
+        doTest(
+            """
+            |Usage: prog [<options>]
+            |
+            |Options:
+            |  -a, --aa=<text>  aa option help (env var: PROG_AA)
+            |  -b, --bb=<text>  bb option help (env var: BB)
+            """
+        )
+    }
+
+    @[Test JsName("envvar_option_tag_not_shown_by_default")]
+    fun `envvar option tag not shown by default`() {
+        c.registerOption(c.option("--aa", "-a", help = "aa option help", envvar = "AA"))
+        doTest(
+            """
+            |Usage: prog [<options>]
+            |
+            |Options:
+            |  -a, --aa=<text>  aa option help
+            """
+        )
+    }
+
+    @[Test JsName("explicit_envvar_tag_shown_when_showEnvvarsInHelp_disabled")]
+    fun `explicit envvar tag shown when showEnvvarsInHelp disabled`() {
+        c.registerOption(
+            c.option(
+                "--aa", "-a", help = "aa option help", envvar = "AA",
+                helpTags = mapOf(HelpFormatter.Tags.ENVVAR to "AA")
+            )
+        )
+        doTest(
+            """
+            |Usage: prog [<options>]
+            |
+            |Options:
+            |  -a, --aa=<text>  aa option help (env var: AA)
+            """
+        )
+    }
+
+    @[Test JsName("blank_envvar_tag_hidden_when_showEnvvarsInHelp_enabled")]
+    fun `blank envvar tag hidden when showEnvvarsInHelp enabled`() {
+        c.registerOption(c.option("--aa", "-a", help = "aa option help", envvar = "AA"))
+        c.registerOption(
+            c.option(
+                "--bb", "-b", help = "bb option help", envvar = "BB",
+                helpTags = mapOf(HelpFormatter.Tags.ENVVAR to "")
+            )
+        )
+        c.context { showEnvvarsInHelp = true }
+        doTest(
+            """
+            |Usage: prog [<options>]
+            |
+            |Options:
+            |  -a, --aa=<text>  aa option help (env var: AA)
+            |  -b, --bb=<text>  bb option help
+            """
+        )
+    }
+
+    @[Test JsName("envvar_option_tag_not_shown_for_eager_options")]
+    fun `envvar option tag not shown for eager options`() {
+        c.context {
+            autoEnvvarPrefix = "PROG"
+            showEnvvarsInHelp = true
+        }
+        doTest(
+            """
+            |Usage: prog [<options>]
+            |
+            |Options:
+            |  -h, --help  Show this message and exit
+            """,
+            helpNames = setOf("-h", "--help"),
+        )
+    }
+
+    @[Test JsName("envvar_option_tag_inherited_by_subcommands")]
+    fun `envvar option tag setting inherited by subcommands`() {
+        class Sub : TestCommand(name = "sub") {
+            val opt by option(help = "opt help", envvar = "OPT")
+        }
+
+        val c = TestCommand(name = "prog").context { showEnvvarsInHelp = true }
+            .subcommands(Sub())
+        c.test("sub --help").output shouldContain "(env var: OPT)"
     }
 
     @[Test JsName("custom_tag")]

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/PlaintextHelpFormatterTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/output/PlaintextHelpFormatterTest.kt
@@ -446,6 +446,22 @@ class PlaintextHelpFormatterTest {
         )
     }
 
+    @[Test JsName("envvar_option_tag")]
+    fun `envvar option tag`() {
+        c.registerOption(c.option("--aa", "-a", help = "aa option help"))
+        c.registerOption(c.option("--bb", "-b", help = "bb option help", envvar = "BB"))
+        c.context { showEnvvarsInHelp = true }
+        doTest(
+            """
+            |Usage: prog [<options>]
+            |
+            |Options:
+            |  -a, --aa=<text>  aa option help
+            |  -b, --bb=<text>  bb option help (env var: BB)
+            """
+        )
+    }
+
     @[Test JsName("custom_tag")]
     fun `custom tag`() {
         c.registerOption(c.option("--aa", "-a", help = "aa option help"))


### PR DESCRIPTION

Adds an opt-in way to show the name of the environment variable that an option reads its value from in the `--help` output:

```kotlin
class Tool : CliktCommand() {
    init {
        context {
            autoEnvvarPrefix = "TOOL"
            showEnvvarsInHelp = true
        }
    }
    val explicit by option(help = "explicit envvar name", envvar = "MY_OPTION")
    val inferred by option(help = "inferred envvar name")
}
```

```text
Options:
  --explicit=<text>  explicit envvar name (env var: MY_OPTION)
  --inferred=<text>  inferred envvar name (env var: TOOL_INFERRED)
  -h, --help         Show this message and exit
```

Both explicit `envvar` names and names inferred from `autoEnvvarPrefix` are shown. Eager options (like `--help` and `--version`) never read envvars, so they never get the tag.


The tag is computed in `Option.parameterHelp(context)` - the only place with access to both the option's `envvar` and the context's `autoEnvvarPrefix` — and flows through the existing help tag pipeline, so no formatter changes were needed beyond localizing the new `HelpFormatter.Tags.ENVVAR` tag. It renders identically in `MordantHelpFormatter`, `PlaintextHelpFormatter`, and the markdown formatter.

That also means all the existing customization hooks apply to it for free:

- label text: `Localization.helpTagEnvvar()` (defaults to `"env var"`)
- format/visibility: the open `renderTag` / `shouldShowTag` formatter methods
- styling: `styleHelpTag` (`theme.style("muted")`), same as the other tags

## Per-option override

Individual options can override the global setting through their existing `helpTags` parameter:

```kotlin
// hide the envvar name for one option while showEnvvarsInHelp is on:
val secret by option(envvar = "TOOL_SECRET", helpTags = mapOf(HelpFormatter.Tags.ENVVAR to ""))

// or show it for one option while the setting is off:
val opt by option(envvar = "TOOL_OPT", helpTags = mapOf(HelpFormatter.Tags.ENVVAR to "TOOL_OPT"))
```

## Default

The setting is **off by default**, so existing help output is byte-identical. Since envvar support is invisible to users without this (see request in #320), probably it is worth enabling it by default in a future release - happy to follow whatever you prefer here.


Closes #320
