### PR TITLE
Add `negatable` parameter to `flag()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Added `negatable` parameter to `flag` and `nullableFlag` to automatically derive a `--no-` prefixed negation from each long name of the option (e.g. `option("--cache").flag(negatable = true)` registers both `--cache` and `--no-cache`). ([#642](https://github.com/ajalt/clikt/pull/642))
 
 ## 5.1.0
 ### Added

--- a/clikt/api/clikt.api
+++ b/clikt/api/clikt.api
@@ -1038,9 +1038,10 @@ public final class com/github/ajalt/clikt/parameters/options/FlagOptionKt {
 	public static final fun convert (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;Lkotlin/jvm/functions/Function2;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static final fun counted (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;IZ)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static synthetic fun counted$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;IZILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
-	public static final fun flag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
-	public static synthetic fun flag$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
-	public static final fun nullableFlag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static final fun flag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;Z)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static synthetic fun flag$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;ZILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static final fun nullableFlag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;Z)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static synthetic fun nullableFlag$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static final fun switch (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;Ljava/util/Map;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static final fun switch (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Lkotlin/Pair;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -15,6 +15,10 @@ typealias FlagConverter<InT, OutT> = OptionTransformContext.(InT) -> OutT
  * @param default the value for this property if the option is not given on the command line.
  * @param defaultForHelp The help text for this option's default value if the help formatter is configured
  *   to show them.
+ * @param negatable If true and no [secondaryNames] are given, derive a `--no-` prefixed negation from each
+ *   long name of this option (e.g. `--cache` gets a `--no-cache` that sets the value to false). Requires at
+ *   least one long (`--`) name to derive from. Pass explicit [secondaryNames] instead for names where the
+ *   `--no-` convention doesn't fit (e.g. `--enable` paired with `--disable`).
  *
  * ### Example:
  *
@@ -22,14 +26,18 @@ typealias FlagConverter<InT, OutT> = OptionTransformContext.(InT) -> OutT
  * val flag by option(help = "flag option").flag("--no-flag", default = true, defaultForHelp = "enable")
  * // Options:
  * // --flag / --no-flag  flag option (default: enable)
+ *
+ * // The same flag with the negation derived automatically from the --long name:
+ * val cache by option("--cache", help = "flag option").flag(default = true, negatable = true)
  * ```
  */
 fun RawOption.flag(
     vararg secondaryNames: String,
     default: Boolean = false,
     defaultForHelp: String = "",
+    negatable: Boolean = false,
 ): OptionWithValues<Boolean, Boolean, Boolean> {
-    return nullableFlag(*secondaryNames)
+    return nullableFlag(*secondaryNames, negatable = negatable)
         .default(default, defaultForHelp = defaultForHelp)
 }
 
@@ -38,16 +46,33 @@ fun RawOption.flag(
  *
  * You will usually want [flag] instead of this function, but this can be useful if you need to use
  * a [transformAll] method like [required] or `prompt`.
+ *
+ * See [flag] for the meaning of [negatable].
  */
-fun RawOption.nullableFlag(vararg secondaryNames: String): NullableOption<Boolean, Boolean> {
+fun RawOption.nullableFlag(
+    vararg secondaryNames: String,
+    negatable: Boolean = false,
+): NullableOption<Boolean, Boolean> {
+    val negations: Set<String> = when {
+        secondaryNames.isNotEmpty() -> secondaryNames.toSet()
+        negatable -> {
+            val longNames = names.filter { it.startsWith("--") }
+            require(longNames.isNotEmpty()) {
+                "negatable requires an explicit long option name to derive a \"--no-\" negation from"
+            }
+            longNames.mapTo(mutableSetOf()) { "--no-" + it.removePrefix("--") }
+        }
+
+        else -> emptySet()
+    }
     return boolean()
         .transformValues(0..0) {
             if (it.size > 1) {
                 fail(context.localization.invalidFlagValueInFile(name))
             }
-            it.lastOrNull() ?: (name !in secondaryNames)
+            it.lastOrNull() ?: (name !in negations)
         }
-        .copy(secondaryNames = secondaryNames.toSet())
+        .copy(secondaryNames = negations)
 }
 
 /**

--- a/docs/options.md
+++ b/docs/options.md
@@ -415,6 +415,39 @@ previously.
     ```
 
 
+Rather than spelling out the negation, you can set `negatable = true` to
+derive a `--no-` prefixed name from each long name of the option
+automatically — the conventional `--foo` / `--no-foo` pairing used by
+GNU-style tools, mirroring Python's argparse `BooleanOptionalAction`.
+Invoking the derived name sets the flag to false:
+
+=== "Example"
+    ```kotlin
+    class Cli : CliktCommand() {
+        val cache by option("--cache").flag(default = true, negatable = true)
+        override fun run() {
+            echo(cache)
+        }
+    }
+    ```
+
+=== "Usage 1"
+    ```text
+    $ ./cli
+    true
+    ```
+
+=== "Usage 2"
+    ```text
+    $ ./cli --no-cache
+    false
+    ```
+
+For names where the `--no-` convention doesn't fit (e.g. `--enable` paired
+with `--disable`), pass the secondary names explicitly instead; explicit
+secondary names take precedence over `negatable`.
+
+
 Multiple short flag options can be combined when called on the command
 line:
 

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/FlagOptionTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/FlagOptionTest.kt
@@ -1,0 +1,68 @@
+package com.github.ajalt.clikt.parameters
+
+import com.github.ajalt.clikt.core.NoSuchOption
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.parse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import kotlin.js.JsName
+import kotlin.test.Test
+
+@Suppress("unused")
+class FlagOptionTest {
+    @[Test JsName("negatable_derives_negation")]
+    fun `negatable derives a --no- negation`() = forAll(
+        row("", true),
+        row("--cache", true),
+        row("--no-cache", false),
+        row("--no-cache --cache", true),
+        row("--cache --no-cache", false),
+    ) { argv, expected ->
+        class C : TestCommand() {
+            val cache by option("--cache").flag(default = true, negatable = true)
+            override fun run_() {
+                cache shouldBe expected
+            }
+        }
+        C().parse(argv)
+    }
+
+    @[Test JsName("negatable_derives_for_each_long_name")]
+    fun `negatable derives a negation for each long name`() = forAll(
+        row("--no-cache", false),
+        row("--no-cc", false),
+    ) { argv, expected ->
+        class C : TestCommand() {
+            val cache by option("-c", "--cache", "--cc").flag(default = true, negatable = true)
+            override fun run_() {
+                cache shouldBe expected
+            }
+        }
+        C().parse(argv)
+    }
+
+    @[Test JsName("explicit_secondary_names_win_over_negatable")]
+    fun `explicit secondary names win over negatable`() {
+        class C : TestCommand() {
+            val enabled by option("--enable").flag("--disable", default = true, negatable = true)
+            override fun run_() {
+                enabled shouldBe false
+            }
+        }
+        C().parse("--disable")
+        // negatable was overridden by the explicit --disable, so --no-enable was never registered
+        shouldThrow<NoSuchOption> { C().parse("--no-enable") }
+    }
+
+    @[Test JsName("negatable_without_long_name_throws")]
+    fun `negatable without a long name throws at construction`() {
+        class C : TestCommand(called = false) {
+            val quiet by option("-q").flag(negatable = true)
+        }
+        shouldThrow<IllegalArgumentException> { C() }
+    }
+}


### PR DESCRIPTION
Auto-derive a `--no-`-prefixed negation from each long name of a boolean flag, opt-in, built on the existing `flag()` machinery (option names) rather than a parallel API:

```kotlin
val cache by option("--cache").flag(default = true, negatable = true)  // --cache / --no-cache
```

- Off by default, so a plain `flag()` (e.g. `--verbose`, `--force`) stays negation-less — no behavior change for existing flags.
- Explicit `secondaryNames` still work and take precedence, for names where `--no-` doesn't fit (`--enable` / `--disable`).
- Requires at least one long (`--`) name to derive from; `flag(negatable = true)` on a short-only option throws at construction rather than silently doing nothing.
- Derivation is intentionally simple (`--x` → `--no-x`); it doesn't special-case already-negative names (`--no-x` → `--no-no-x`). Pass explicit `secondaryNames` there. No new collision detection — an inferred `--no-x` that duplicates another option's name follows the same last-one-wins behavior Clikt already has for explicit duplicate names.

## Prior art

Auto-deriving the negative form of a boolean flag is well-established. POSIX only standardizes short options, so `--foo`/`--no-foo` is a convention rather than a formal rule — but a pervasive one, and several libraries already auto-generate the pair:

- **GNU long options** conventionally pair `--foo` with `--no-foo` ([GNU C Library — Argument Syntax](https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html)).
- **Perl's `Getopt::Long`** auto-generates `--no-foo`/`--nofoo` from a boolean (`"foo!"`) spec — the same auto-derivation `negatable` does here.
- **Python's `argparse`** formalized it as [`BooleanOptionalAction`](https://docs.python.org/3/library/argparse.html#argparse.BooleanOptionalAction), added in **Python 3.9** (2020), registering both `--foo` and `--no-foo` from one declaration.
- **Ruby's `OptionParser`** supports the `--[no-]foo` spelling for the same purpose.

A companion PR, #643, adds an orthogonal `acceptsValue` option (the `--flag=true|false` value form); the two compose.

Includes the regenerated ABI dump, changelog, docs, and tests (`FlagOptionTest`).
