### PR TITLE
Add `acceptsValue` parameter to `flag()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Added `acceptsValue` parameter to `flag` and `nullableFlag` to let a flag also accept an explicit attached value, e.g. `--flag=true` or `--flag=false` (parsed leniently, like `boolean()`; the value must be attached with `=`). ([#643](https://github.com/ajalt/clikt/pull/643))
 
 ## 5.1.0
 ### Added

--- a/clikt/api/clikt.api
+++ b/clikt/api/clikt.api
@@ -713,6 +713,7 @@ public abstract interface class com/github/ajalt/clikt/output/Localization {
 	public fun unclosedQuote ()Ljava/lang/String;
 	public fun usageError ()Ljava/lang/String;
 	public fun usageTitle ()Ljava/lang/String;
+	public fun valueOnFlagNegation (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/github/ajalt/clikt/output/Localization$DefaultImpls {
@@ -774,6 +775,7 @@ public final class com/github/ajalt/clikt/output/Localization$DefaultImpls {
 	public static fun unclosedQuote (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun usageError (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
 	public static fun usageTitle (Lcom/github/ajalt/clikt/output/Localization;)Ljava/lang/String;
+	public static fun valueOnFlagNegation (Lcom/github/ajalt/clikt/output/Localization;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public abstract interface class com/github/ajalt/clikt/output/ParameterFormatter {
@@ -1038,9 +1040,10 @@ public final class com/github/ajalt/clikt/parameters/options/FlagOptionKt {
 	public static final fun convert (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;Lkotlin/jvm/functions/Function2;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static final fun counted (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;IZ)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static synthetic fun counted$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;IZILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
-	public static final fun flag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
-	public static synthetic fun flag$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
-	public static final fun nullableFlag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static final fun flag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;Z)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static synthetic fun flag$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZLjava/lang/String;ZILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static final fun nullableFlag (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;Z)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
+	public static synthetic fun nullableFlag$default (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Ljava/lang/String;ZILjava/lang/Object;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static final fun switch (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;Ljava/util/Map;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 	public static final fun switch (Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;[Lkotlin/Pair;)Lcom/github/ajalt/clikt/parameters/options/OptionWithValues;
 }

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/output/Localization.kt
@@ -116,6 +116,16 @@ interface Localization {
     /** Error message when reading flag option from a file */
     fun invalidFlagValueInFile(name: String) = "invalid flag value in file for option $name"
 
+    /**
+     * Error message when a value is given to a flag's negation (secondary) name, e.g. `--no-foo=1`
+     *
+     * @param negationName the negation name that was used, e.g. `--no-foo`
+     * @param positiveName the flag's positive name, e.g. `--foo`
+     * @param value the value that was given
+     */
+    fun valueOnFlagNegation(negationName: String, positiveName: String, value: String) =
+        "maybe you mean $positiveName=$value. Or use $negationName to disable"
+
     /** Error message when reading switch option from environment variable */
     fun switchOptionEnvvar() = "environment variables not supported for switch options"
 

--- a/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
+++ b/clikt/src/commonMain/kotlin/com/github/ajalt/clikt/parameters/options/FlagOption.kt
@@ -15,6 +15,10 @@ typealias FlagConverter<InT, OutT> = OptionTransformContext.(InT) -> OutT
  * @param default the value for this property if the option is not given on the command line.
  * @param defaultForHelp The help text for this option's default value if the help formatter is configured
  *   to show them.
+ * @param acceptsValue If true, this flag also accepts an explicit attached value like `--flag=true` or
+ *   `--flag=false`. The value is parsed leniently (`true/t/1/yes/y/on` ↔ `false/f/0/no/n/off`, case
+ *   insensitive; an empty value is an error). The value must be attached with `=`; a bare `--flag` still means
+ *   true (or false for a [secondaryNames] negation name), and giving a value to a negation name is an error.
  *
  * ### Example:
  *
@@ -22,14 +26,18 @@ typealias FlagConverter<InT, OutT> = OptionTransformContext.(InT) -> OutT
  * val flag by option(help = "flag option").flag("--no-flag", default = true, defaultForHelp = "enable")
  * // Options:
  * // --flag / --no-flag  flag option (default: enable)
+ *
+ * // The same flag also accepting an explicit value: --flag, --no-flag, --flag=true, --flag=false
+ * val flag by option("--flag", help = "flag option").flag("--no-flag", default = true, acceptsValue = true)
  * ```
  */
 fun RawOption.flag(
     vararg secondaryNames: String,
     default: Boolean = false,
     defaultForHelp: String = "",
+    acceptsValue: Boolean = false,
 ): OptionWithValues<Boolean, Boolean, Boolean> {
-    return nullableFlag(*secondaryNames)
+    return nullableFlag(*secondaryNames, acceptsValue = acceptsValue)
         .default(default, defaultForHelp = defaultForHelp)
 }
 
@@ -38,16 +46,27 @@ fun RawOption.flag(
  *
  * You will usually want [flag] instead of this function, but this can be useful if you need to use
  * a [transformAll] method like [required] or `prompt`.
+ *
+ * See [flag] for the meaning of [acceptsValue].
  */
-fun RawOption.nullableFlag(vararg secondaryNames: String): NullableOption<Boolean, Boolean> {
+fun RawOption.nullableFlag(
+    vararg secondaryNames: String,
+    acceptsValue: Boolean = false,
+): NullableOption<Boolean, Boolean> {
+    val secondary = secondaryNames.toSet()
     return boolean()
-        .transformValues(0..0) {
-            if (it.size > 1) {
+        .transformValues(if (acceptsValue) 0..1 else 0..0) { values ->
+            if (values.size > 1) {
                 fail(context.localization.invalidFlagValueInFile(name))
             }
-            it.lastOrNull() ?: (name !in secondaryNames)
+            val value = values.lastOrNull()
+            if (value != null && name in secondary) {
+                val positiveName = names.firstOrNull { it.startsWith("--") } ?: name
+                fail(context.localization.valueOnFlagNegation(name, positiveName, value.toString()))
+            }
+            value ?: (name !in secondary)
         }
-        .copy(secondaryNames = secondaryNames.toSet())
+        .copy(secondaryNames = secondary, acceptsUnattachedValue = !acceptsValue)
 }
 
 /**

--- a/docs/options.md
+++ b/docs/options.md
@@ -415,6 +415,29 @@ previously.
     ```
 
 
+A boolean flag can also accept an explicit value if you set `acceptsValue =
+true`. The value must be attached with `=`, and is parsed leniently (the
+same spellings as `boolean()`: `true`/`t`/`1`/`yes`/`y`/`on` and their
+negatives, case-insensitive). This is handy when the value comes from a
+script or environment variable that already holds a boolean string:
+
+=== "Example"
+    ```kotlin
+    class Cli : CliktCommand() {
+        val cache by option("--cache").flag("--no-cache", default = true, acceptsValue = true)
+        override fun run() {
+            echo(cache)
+        }
+    }
+    ```
+
+=== "Usage"
+    ```text
+    $ ./cli --cache=false
+    false
+    ```
+
+
 Multiple short flag options can be combined when called on the command
 line:
 

--- a/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/FlagValueTest.kt
+++ b/test/src/commonTest/kotlin/com/github/ajalt/clikt/parameters/FlagValueTest.kt
@@ -1,0 +1,91 @@
+package com.github.ajalt.clikt.parameters
+
+import com.github.ajalt.clikt.core.BadParameterValue
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.testing.TestCommand
+import com.github.ajalt.clikt.testing.formattedMessage
+import com.github.ajalt.clikt.testing.parse
+import com.github.ajalt.clikt.testing.withEnv
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlin.js.JsName
+import kotlin.test.Test
+
+@Suppress("unused")
+class FlagValueTest {
+    @[Test JsName("acceptsValue_parses_attached_value")]
+    fun `acceptsValue parses an attached value`() = forAll(
+        row("", false),
+        row("--x", true),
+        row("--x=true", true),
+        row("--x=false", false),
+        row("--x=yes", true),
+        row("--x=ON", true),
+        row("--x=0", false),
+        row("--x=true --x=no", false),
+    ) { argv, expected ->
+        class C : TestCommand() {
+            val x by option("--x").flag(acceptsValue = true)
+            override fun run_() {
+                x shouldBe expected
+            }
+        }
+        C().parse(argv)
+    }
+
+    @[Test JsName("acceptsValue_rejects_empty_value")]
+    fun `acceptsValue rejects an empty value`() {
+        class C : TestCommand(called = false) {
+            val x by option("--x").flag(acceptsValue = true)
+        }
+        shouldThrow<BadParameterValue> { C().parse("--x=") }
+    }
+
+    @[Test JsName("acceptsValue_requires_attached_value")]
+    fun `acceptsValue requires the value to be attached`() {
+        class C : TestCommand() {
+            val x by option("--x").flag(acceptsValue = true)
+            val arg by argument()
+            override fun run_() {
+                // the unattached "true" is a positional, not the flag's value
+                x shouldBe true
+                arg shouldBe "true"
+            }
+        }
+        C().parse("--x true")
+    }
+
+    @[Test JsName("acceptsValue_reads_envvar")]
+    fun `acceptsValue reads its value from an envvar`() {
+        class C : TestCommand() {
+            val x by option("--x", envvar = "X").flag(default = true, acceptsValue = true)
+            override fun run_() {
+                x shouldBe false
+            }
+        }
+        C().withEnv("X" to "false").parse("")
+    }
+
+    @[Test JsName("acceptsValue_rejects_empty_envvar")]
+    fun `acceptsValue rejects an empty envvar value`() {
+        class C : TestCommand(called = false) {
+            val x by option("--x", envvar = "X").flag(default = true, acceptsValue = true)
+        }
+        shouldThrow<BadParameterValue> { C().withEnv("X" to "").parse("") }
+    }
+
+    @[Test JsName("value_on_secondary_name_is_an_error")]
+    fun `a value on a secondary name is an error pointing to the positive form`() {
+        class C : TestCommand(called = false) {
+            val cache by option("--cache").flag("--no-cache", default = true, acceptsValue = true)
+        }
+        val message = shouldThrow<BadParameterValue> { C().parse("--no-cache=true") }.formattedMessage
+        message shouldContain "maybe you mean --cache=true"
+        message shouldContain "Or use --no-cache to disable"
+    }
+}


### PR DESCRIPTION
Lets a boolean flag also accept an explicit attached value, parsed by the existing lenient `boolean()` converter — handy when the value comes from a script or environment variable that already holds a boolean string:

```kotlin
val cache by option("--cache").flag("--no-cache", default = true, acceptsValue = true)
// --cache, --no-cache, AND --cache=true|false
```

- Off by default, so existing flags are unchanged.
- Widens the flag's arity to `0..1`. The value must be attached with `=` (`acceptsUnattachedValue = false`), so `--cache value` stays unambiguous with a positional argument.
- An empty value is an error (`boolean()` already rejects it) — useful when the value comes from an envvar that may be misconfigured.
- Giving a value to a secondary/negation name (`--no-cache=true`) is an error pointing at the positive form, via a new `Localization.valueOnFlagNegation`.

Companion to #642 (`negatable`). The two are orthogonal and compose — with both, `option("--cache").flag(negatable = true, acceptsValue = true)` accepts `--cache`, `--no-cache`, and `--cache=true|false`. They touch the same `flag`/`nullableFlag` functions, so whichever lands second needs a small rebase (happy to do it).

Includes the regenerated ABI dump, changelog, docs, and tests (`FlagValueTest`).
